### PR TITLE
Metadata improvements

### DIFF
--- a/crc-bundle-info.json.sample
+++ b/crc-bundle-info.json.sample
@@ -22,7 +22,7 @@
     "masterHostname": "crc-qw8kr-master-0",
     # Name of a file containing an SSH private key which can be used to connect to
     # the cluster nodes
-    "sshPrivateKeyFile": "master_privatekey",
+    "sshPrivateKeyFile": "id_rsa_crc",
     # Name of the kubeconfig file stored in the bundle
     "kubeConfig": "kubeconfig",
     # Name of the file containing the kubeadmin password for use in the

--- a/crc-bundle-info.json.sample
+++ b/crc-bundle-info.json.sample
@@ -1,4 +1,8 @@
 {
+  # Version of the bundle, used to denote format changes
+  # Major is only increased changes incompatible with previous versions
+  # Minor is increased for backwards-compatible changes
+  "version": "1.0",
   # Type of this bundle content
   # Currently the only valid type is 'snc' (which stands for 'single-node-cluster')
   "type": "snc",

--- a/crc-bundle-info.json.sample
+++ b/crc-bundle-info.json.sample
@@ -16,6 +16,8 @@
     "clusterName": "crc",
     # Base domain name used for the openshift cluster
     "baseDomain": "testing",
+    # Subdomain where the apps will go
+    "appsDomain": "apps-crc.testing",
     # Hostname of the master node
     "masterHostname": "crc-qw8kr-master-0",
     # Name of a file containing an SSH private key which can be used to connect to

--- a/crc-bundle-info.json.sample
+++ b/crc-bundle-info.json.sample
@@ -18,8 +18,6 @@
     "baseDomain": "testing",
     # Subdomain where the apps will go
     "appsDomain": "apps-crc.testing",
-    # Hostname of the master node
-    "masterHostname": "crc-qw8kr-master-0",
     # Name of a file containing an SSH private key which can be used to connect to
     # the cluster nodes
     "sshPrivateKeyFile": "id_rsa_crc",
@@ -29,6 +27,20 @@
     # openshift console
     "kubeadminPasswordFile": "kubeadmin-password"
   },
+  "nodes": [
+    {
+      # Type of the node, can be 'master', 'worker' or both
+      "kind": [
+        "master",
+        "worker"
+      ],
+      # Hostname of the node
+      "hostname": "crc-88lpx-master-0",
+      # Disk image used by the node, the 'storage' object will contain more
+      # details about its format
+      "diskImage": "crc.qcow2"
+    }
+  ],
   "storage": {
     # List of virtual machine disk images in the bundle
     "diskImages": [

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -48,10 +48,13 @@ function create_disk_image {
 
 function update_json_description {
     cat $1/crc-bundle-info.json \
-        | ${JQ} ".clusterInfo.masterHostname = \"${VM_PREFIX}-master-0\"" \
         | ${JQ} '.clusterInfo.sshPrivateKeyFile = "id_rsa_crc"' \
         | ${JQ} '.clusterInfo.kubeConfig = "kubeconfig"' \
         | ${JQ} '.clusterInfo.kubeadminPasswordFile = "kubeadmin-password"' \
+        | ${JQ} '.nodes[0].kind[0] = "master"' \
+        | ${JQ} '.nodes[0].kind[1] = "worker"' \
+        | ${JQ} ".nodes[0].hostname = \"${VM_PREFIX}-master-0\"" \
+        | ${JQ} ".nodes[0].diskImage = \"${CRC_VM_NAME}.qcow2\"" \
         | ${JQ} ".storage.diskImages[0].name = \"${CRC_VM_NAME}.qcow2\"" \
         | ${JQ} '.storage.diskImages[0].format = "qcow2"' \
         >$tarballDirectory/crc-bundle-info.json

--- a/snc.sh
+++ b/snc.sh
@@ -27,7 +27,11 @@ function create_json_description {
 # Download the oc binary if not present in current directory
 if ! which $OC; then
     if [[ ! -e oc ]] ; then
-        curl -L https://mirror.openshift.com/pub/openshift-v3/clients/4.0.22/linux/oc.tar.gz -o oc.tar.gz
+        if [ -n ${OPENSHIFT_RELEASE_VERSION} ]; then
+            curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux-${OPENSHIFT_RELEASE_VERSION}.tar.gz -o oc.tar.gz
+        else
+            curl -L https://mirror.openshift.com/pub/openshift-v3/clients/4.0.22/linux/oc.tar.gz -o oc.tar.gz
+        fi
         tar -xvf oc.tar.gz
         rm -fr oc.tar.gz
     fi

--- a/snc.sh
+++ b/snc.sh
@@ -18,7 +18,8 @@ function create_json_description {
             | ${JQ} ".buildInfo.openshiftInstallerVersion = \"${openshiftInstallerVersion}\"" \
             | ${JQ} ".buildInfo.sncVersion = \"git${sncGitHash}\"" \
             | ${JQ} ".clusterInfo.clusterName = \"${CRC_VM_NAME}\"" \
-            | ${JQ} ".clusterInfo.baseDomain = \"${BASE_DOMAIN}\"" >${INSTALL_DIR}/crc-bundle-info.json
+            | ${JQ} ".clusterInfo.baseDomain = \"${BASE_DOMAIN}\"" \
+            | ${JQ} ".clusterInfo.appsDomain = \"apps-${CRC_VM_NAME}.${BASE_DOMAIN}\"" >${INSTALL_DIR}/crc-bundle-info.json
     #        |${JQ} '.buildInfo.ocGetCo = "snc"' >${INSTALL_DIR}/crc-bundle-info.json
 }
 

--- a/snc.sh
+++ b/snc.sh
@@ -28,12 +28,10 @@ function create_json_description {
 if ! which $OC; then
     if [[ ! -e oc ]] ; then
         if [ -n ${OPENSHIFT_RELEASE_VERSION} ]; then
-            curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux-${OPENSHIFT_RELEASE_VERSION}.tar.gz -o oc.tar.gz
+            curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux-${OPENSHIFT_RELEASE_VERSION}.tar.gz | tar zx oc
         else
-            curl -L https://mirror.openshift.com/pub/openshift-v3/clients/4.0.22/linux/oc.tar.gz -o oc.tar.gz
+            curl -L https://mirror.openshift.com/pub/openshift-v3/clients/4.0.22/linux/oc.tar.gz | tar zx oc
         fi
-        tar -xvf oc.tar.gz oc
-        rm -fr oc.tar.gz
     fi
     OC=./oc
 fi

--- a/snc.sh
+++ b/snc.sh
@@ -32,7 +32,7 @@ if ! which $OC; then
         else
             curl -L https://mirror.openshift.com/pub/openshift-v3/clients/4.0.22/linux/oc.tar.gz -o oc.tar.gz
         fi
-        tar -xvf oc.tar.gz
+        tar -xvf oc.tar.gz oc
         rm -fr oc.tar.gz
     fi
     OC=./oc

--- a/snc.sh
+++ b/snc.sh
@@ -30,7 +30,7 @@ if ! which $OC; then
         if [ -n ${OPENSHIFT_RELEASE_VERSION} ]; then
             curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux-${OPENSHIFT_RELEASE_VERSION}.tar.gz | tar zx oc
         else
-            curl -L https://mirror.openshift.com/pub/openshift-v3/clients/4.0.22/linux/oc.tar.gz | tar zx oc
+            curl -L https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz | tar zx oc
         fi
     fi
     OC=./oc

--- a/snc.sh
+++ b/snc.sh
@@ -6,6 +6,7 @@ JQ=${JQ:-jq}
 OC=${OC:-oc}
 YQ=${YQ:-yq}
 OPENSHIFT_INSTALL=${OPENSHIFT_INSTALL:-./openshift-install}
+OPENSHIFT_RELEASE_VERSION=$(git describe --abbrev=0 HEAD 2>/dev/null) || OPENSHIFT_RELEASE_VERSION=
 CRC_VM_NAME=${CRC_VM_NAME:-crc}
 BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
 
@@ -52,6 +53,13 @@ ${OPENSHIFT_INSTALL} --dir $INSTALL_DIR destroy cluster --log-level debug
 if [ "${OPENSHIFT_PULL_SECRET}" = "" ]; then
     echo "OpenShift pull secret must be specified through the OPENSHIFT_PULL_SECRET environment variable"
     exit 1
+fi
+
+# Use the release payload for the latest known openshift release as indicated by git tags
+if [ -n ${OPENSHIFT_RELEASE_VERSION} ]; then
+    OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=quay.io/openshift-release-dev/ocp-release:${OPENSHIFT_RELEASE_VERSION}
+    export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE
+    echo "Setting OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE to ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE}"
 fi
 
 # Create the INSTALL_DIR for the installer and copy the install-config

--- a/snc.sh
+++ b/snc.sh
@@ -14,7 +14,8 @@ BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
 function create_json_description {
     openshiftInstallerVersion=$(${OPENSHIFT_INSTALL} version)
     sncGitHash=$(git describe --abbrev=4 HEAD 2>/dev/null || git rev-parse --short=4 HEAD)
-    echo {} | ${JQ} '.type = "snc"' \
+    echo {} | ${JQ} '.version = "1.0"' \
+            | ${JQ} '.type = "snc"' \
             | ${JQ} ".buildInfo.buildTime = \"$(date -u --iso-8601=seconds)\"" \
             | ${JQ} ".buildInfo.openshiftInstallerVersion = \"${openshiftInstallerVersion}\"" \
             | ${JQ} ".buildInfo.sncVersion = \"git${sncGitHash}\"" \


### PR DESCRIPTION
This pull request is on top of #14 
2 of the commits make use of git tags to detect which openshift release we are building for, and adjust a few things accordingly.
The other commits improve the crc-bundle-info.json file to add missing data, the most notable one being the addition of a `nodes` array describing the cluster nodes.