### PR TITLE
Enable lazy_refcounts on the qcow2 image we ship

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -44,7 +44,7 @@ function create_qemu_image {
 
     # Resize the image from the default 1+15GB to 1+20GB
     # This should also take care of making the image sparse
-    ${QEMU_IMG} create -f qcow2 $destDir/${CRC_VM_NAME}.qcow2 21G
+    ${QEMU_IMG} create -o lazy_refcounts=on -f qcow2 $destDir/${CRC_VM_NAME}.qcow2 21G
     ${VIRT_RESIZE} --expand /dev/sda3 $destDir/${VM_PREFIX}-base $destDir/${CRC_VM_NAME}.qcow2
 
     rm -fr $destDir/${VM_PREFIX}-master-0 $destDir/${VM_PREFIX}-base


### PR DESCRIPTION
This works around a bug in hyperkit qcow2 implementation on macos which
would cause the whole VM to freeze when it tries to dynamically grow the
qcow2 image
https://github.com/moby/hyperkit/issues/221

Lazy refcounts are a qcow2 performance improvement which should not have
many adverse effects (slower startup in case of improper VM shutdown),
see https://lists.gnu.org/archive/html/qemu-devel/2012-06/msg03827.html

This fixes #38.
https://github.com/code-ready/snc/issues/38