### PR TITLE
Issue #44 Scale down the ingress router from 2 to 1.

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -199,3 +199,6 @@ ${OC} scale --replicas=0 deployment --all -n openshift-machine-config-operator
 
 # Scale route deployment from 2 to 1
 ${OC} patch --patch='{"spec": {"replicas": 1}}' --type=merge ingresscontroller/default -n openshift-ingress-operator
+
+# Set default route for registry CRD from false to true.
+${OC} patch config.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge

--- a/snc.sh
+++ b/snc.sh
@@ -196,3 +196,6 @@ ${OC} delete pods -l 'app in (installer, pruner)' -n openshift-kube-controller-m
 # Disable the deployment/replicaset for openshift-machine-api and openshift-machine-config-operator
 ${OC} scale --replicas=0 deployment --all -n openshift-machine-api
 ${OC} scale --replicas=0 deployment --all -n openshift-machine-config-operator
+
+# Scale route deployment from 2 to 1
+${OC} patch --patch='{"spec": {"replicas": 1}}' --type=merge ingresscontroller/default -n openshift-ingress-operator


### PR DESCRIPTION
As of now default ingress operator deployment have 2 replica for
ingress (which provides routing) since in single node cluster second
one is not going to come up and work.