### PR TITLE
Issue #54 Delete the v1beta1.metrics.k8s.io apiservice

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -202,3 +202,7 @@ ${OC} patch --patch='{"spec": {"replicas": 1}}' --type=merge ingresscontroller/d
 
 # Set default route for registry CRD from false to true.
 ${OC} patch config.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
+
+# Delete the v1beta1.metrics.k8s.io apiservice since we are already scale down cluster wide monitioring.
+# Since this CRD block namespace deletion forever.
+${OC} delete apiservice v1beta1.metrics.k8s.io


### PR DESCRIPTION
On CRC side when a user create a new project/namespace and want to delete,
it goes to hanging state forever. Looking on the kubernetes side and found out
it is occur because of CRD's [0][1], as part of our CRC creation we scale down
the cluster wide monitoring operator[2] which serve 'v1beta1.metrics.k8s.io`.

[0] https://github.com/kubernetes/kubernetes/issues/60807
[1] https://github.com/kubernetes/kubernetes/issues/60807#issuecomment-429754733
[2] https://github.com/code-ready/snc/blob/master/snc.sh#L184-L186