### PR TITLE
Issue #66 Update kubelet unit file

### DIFF
--- a/99_master-kubelet-no-taint.yaml
+++ b/99_master-kubelet-no-taint.yaml
@@ -13,12 +13,14 @@ spec:
       - contents: |
           [Unit]
           Description=Kubernetes Kubelet
-          Wants=rpc-statd.service
+          Wants=rpc-statd.service crio.service
+          After=crio.service
 
           [Service]
           Type=notify
           ExecStartPre=/bin/mkdir --parents /etc/kubernetes/manifests
           ExecStartPre=/bin/rm -f /var/lib/kubelet/cpu_manager_state
+          EnvironmentFile=/etc/os-release
           EnvironmentFile=-/etc/kubernetes/kubelet-workaround
           EnvironmentFile=-/etc/kubernetes/kubelet-env
 
@@ -31,13 +33,14 @@ spec:
                 --container-runtime=remote \
                 --container-runtime-endpoint=/var/run/crio/crio.sock \
                 --allow-privileged \
-                --node-labels=node-role.kubernetes.io/master \
+                --node-labels=node-role.kubernetes.io/master,node.openshift.io/os_id=${ID} \
                 --minimum-container-ttl-duration=6m0s \
                 --client-ca-file=/etc/kubernetes/ca.crt \
                 --cloud-provider= \
                 --volume-plugin-dir=/etc/kubernetes/kubelet-plugins/volume/exec \
                 \
                 --anonymous-auth=false \
+                --v=3 \
 
           Restart=always
           RestartSec=10


### PR DESCRIPTION
With openshift 4.2 current kubelet unit file which is part of
machineconfig resource need update. On 4.2 nodes by default doesn't
have `crio` service up and running and kubelet unit file now start
it since it have `wants` section. This changes also work with 4.1
since in that case it just get the `crio` already running.