### PR TITLE
Issue #68 Use virt-sparsify on created qcow2 image.

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -10,7 +10,7 @@ SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_c
 OC=${OC:-oc}
 
 function get_git_tag {
-    GIT_TAG=$(git describe --exact-match HEAD) || GIT_TAG=
+    GIT_TAG=$(git describe --exact-match --tags HEAD) || GIT_TAG=
 
     # Based on code from git-version-gen
     # Don't declare a version "dirty" merely because a time stamp has changed

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -54,6 +54,10 @@ function create_qemu_image {
     ${QEMU_IMG} create -o lazy_refcounts=on -f qcow2 $destDir/${CRC_VM_NAME}.qcow2 31G
     ${VIRT_RESIZE} --expand /dev/sda3 $destDir/${VM_PREFIX}-base $destDir/${CRC_VM_NAME}.qcow2
 
+    # Make sure you have enough space in /tmp to run VIRT_SPARSIFY
+    # Read limitation section of `man virt-sparsify`.
+    ${VIRT_SPARSIFY} --in-place $destDir/${CRC_VM_NAME}.qcow2
+
     rm -fr $destDir/${VM_PREFIX}-master-0 $destDir/${VM_PREFIX}-base
 }
 
@@ -173,6 +177,7 @@ BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
 JQ=${JQ:-jq}
 VIRT_RESIZE=${VIRT_RESIZE:-virt-resize}
 QEMU_IMG=${QEMU_IMG:-qemu-img}
+VIRT_SPARSIFY=${VIRT_SPARSIFY:-virt-sparsify}
 
 if [[ $# -ne 1 ]]; then
    echo "You need to provide the running cluster directory to copy kubeconfig"

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -228,7 +228,7 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo crictl stopp $(sudo crict
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo crictl rmp $(sudo crictl pods -q)'
 
 # Remove pull secret from the VM
-${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- rm -f /var/lib/kubelet/config.json
+${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rm -f /var/lib/kubelet/config.json'
 
 # Get the rhcos ostree Hash ID
 ostree_hash=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'cat /proc/cmdline | grep -oP "(?<=rhcos-).*(?=/vmlinuz)"')

--- a/snc.sh
+++ b/snc.sh
@@ -9,7 +9,7 @@ JQ=${JQ:-jq}
 OC=${OC:-oc}
 YQ=${YQ:-yq}
 OPENSHIFT_INSTALL=${OPENSHIFT_INSTALL:-./openshift-install}
-OPENSHIFT_RELEASE_VERSION=$(git describe --abbrev=0 HEAD 2>/dev/null) || OPENSHIFT_RELEASE_VERSION=
+OPENSHIFT_RELEASE_VERSION=$(git describe --abbrev=0 --tags 2>/dev/null) || OPENSHIFT_RELEASE_VERSION=
 CRC_VM_NAME=${CRC_VM_NAME:-crc}
 BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
 CRC_PV_DIR="/mnt/pv-data"


### PR DESCRIPTION
virt-sparsify can be used to create vm disk sparse. It is
reducing around ~700MB disk size and also help us to have
smaller tarball.