### PR TITLE
Add clusterInfo.openshiftVersion to crc-bundle-info.json

### DIFF
--- a/crc-bundle-info.json.sample
+++ b/crc-bundle-info.json.sample
@@ -16,6 +16,8 @@
     "sncVersion": "git9662"
   },
   "clusterInfo": {
+    # Version of OpenShift installed in the virtual machine
+    "openshiftVersion": "4.1.11"
     # Name of the openshift cluster stored in the bundle
     "clusterName": "crc",
     # Base domain name used for the openshift cluster

--- a/snc.sh
+++ b/snc.sh
@@ -23,6 +23,7 @@ function create_json_description {
             | ${JQ} ".buildInfo.buildTime = \"$(date -u --iso-8601=seconds)\"" \
             | ${JQ} ".buildInfo.openshiftInstallerVersion = \"${openshiftInstallerVersion}\"" \
             | ${JQ} ".buildInfo.sncVersion = \"git${sncGitHash}\"" \
+            | ${JQ} ".clusterInfo.openshiftVersion = \"${OPENSHIFT_RELEASE_VERSION:-git}\"" \
             | ${JQ} ".clusterInfo.clusterName = \"${CRC_VM_NAME}\"" \
             | ${JQ} ".clusterInfo.baseDomain = \"${BASE_DOMAIN}\"" \
             | ${JQ} ".clusterInfo.appsDomain = \"apps-${CRC_VM_NAME}.${BASE_DOMAIN}\"" >${INSTALL_DIR}/crc-bundle-info.json


### PR DESCRIPTION
It will be useful to crc to let the user know which version of OpenShift
their cluster is running.