### PR TITLE
Issue #75 Add logic to get qcow2 location for 4.2 cluster

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -38,8 +38,13 @@ function create_crc_libvirt_sh {
 function create_qemu_image {
     local destDir=$1
 
-    sudo cp /var/lib/libvirt/images/${VM_PREFIX}-master-0 $destDir
-    sudo cp /var/lib/libvirt/images/${VM_PREFIX}-base $destDir
+    if [ -f /var/lib/libvirt/images/${VM_PREFIX}-master-0 ]; then
+      sudo cp /var/lib/libvirt/images/${VM_PREFIX}-master-0 $destDir
+      sudo cp /var/lib/libvirt/images/${VM_PREFIX}-base $destDir
+    else
+      sudo cp /var/lib/libvirt/openshift-images/${VM_PREFIX}/${VM_PREFIX}-master-0 $destDir
+      sudo cp /var/lib/libvirt/openshift-images/${VM_PREFIX}/${VM_PREFIX}-base $destDir
+    fi
 
     sudo chown $USER:$USER -R $destDir
     ${QEMU_IMG} rebase -b ${VM_PREFIX}-base $destDir/${VM_PREFIX}-master-0


### PR DESCRIPTION
Due to https://github.com/openshift/installer/pull/1956 , now
by default the location of the qcow2 images are part of
`/var/lib/libvirt/openshift/<cluster_name>_<random_hash>` so
this change will make sure we are copy correct file as part of
our CI.