### PR TITLE
Issue #94 Add wait-for command for installer

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -173,6 +173,9 @@ export TF_VAR_libvirt_master_vcpu=4
 export OPENSHIFT_INSTALL_INVOKER="codeReadyContainers"
 
 ${OPENSHIFT_INSTALL} --dir $INSTALL_DIR create cluster --log-level debug
+
+# Wait for install to complete, this provide another 30 mins to make resources (apis) stable
+${OPENSHIFT_INSTALL} --dir $INSTALL_DIR wait-for install-complete --log-level debug
 if [ $? -ne 0 ]; then
     echo "This is known to fail with:
 'pool master is not ready - timed out waiting for the condition'


### PR DESCRIPTION
When running snc.sh, after the cluster started,
we start executing different oc commands for post cluster changes.
Sometime cluster is still not in healthy state and api are not
responding (which need bit more time) and it can fail during execution
of thos oc commands. We should add openshift-install
'wait-for install-complete' just after the run so it can wait till
most of the api are working (mostly give us extra 30 mins).