### PR TITLE
Issue #109 Remove journalctl logs before generating the bundle.

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -308,6 +308,11 @@ ${SCP} core@api.${CRC_VM_NAME}.${BASE_DOMAIN}:/boot/ostree/rhcos-${ostree_hash}/
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rm -fr /etc/cni/net.d/100-crio-bridge.conf'
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rm -fr /etc/cni/net.d/200-loopback.conf'
 
+# Remove the journal logs.
+# Note: With `sudo journalctl --rotate --vacuum-time=1s`, it doesn't 
+# remove all the journal logs so separate commands are used here.
+${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo journalctl --rotate'
+${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo journalctl --vacuum-time=1s'
 
 # Shutdown the VM
 sudo virsh shutdown ${VM_PREFIX}-master-0


### PR DESCRIPTION
~1.5GB data is part of journalctl logs which is part of last run,
better to remove it before creating the bundles.

```
Deleted archived journal /var/log/journal/2567a02e7d8d40ef836b2e565fa8cdd9/system@baf83b88802c423f83b6871da1e0653c-000000000007c5e9-000593920647a0dc.journal (128.0M).
Deleted archived journal /var/log/journal/2567a02e7d8d40ef836b2e565fa8cdd9/system@baf83b88802c423f83b6871da1e0653c-000000000009bad9-00059393e8a944b3.journal (128.0M).
Deleted archived journal /var/log/journal/2567a02e7d8d40ef836b2e565fa8cdd9/system@baf83b88802c423f83b6871da1e0653c-00000000000bafc8-00059395cb7a3919.journal (128.0M).
Deleted archived journal /var/log/journal/2567a02e7d8d40ef836b2e565fa8cdd9/system@baf83b88802c423f83b6871da1e0653c-00000000000da4c3-00059397adb3d626.journal (128.0M).
Deleted archived journal /var/log/journal/2567a02e7d8d40ef836b2e565fa8cdd9/system@baf83b88802c423f83b6871da1e0653c-00000000000f99a3-000593998fcd5fd6.journal (128.0M).
Deleted archived journal /var/log/journal/2567a02e7d8d40ef836b2e565fa8cdd9/system@baf83b88802c423f83b6871da1e0653c-0000000000118c56-0005939b66081357.journal (128.0M).
Deleted archived journal /var/log/journal/2567a02e7d8d40ef836b2e565fa8cdd9/system@baf83b88802c423f83b6871da1e0653c-000000000013813f-0005939d48a5568c.journal (128.0M).
Deleted archived journal /var/log/journal/2567a02e7d8d40ef836b2e565fa8cdd9/system@baf83b88802c423f83b6871da1e0653c-0000000000157549-0005939f25ef9b3c.journal (128.0M).
Deleted archived journal /var/log/journal/2567a02e7d8d40ef836b2e565fa8cdd9/system@baf83b88802c423f83b6871da1e0653c-0000000000176a2e-000593a1086ed7ee.journal (128.0M).
Deleted archived journal /var/log/journal/2567a02e7d8d40ef836b2e565fa8cdd9/system@baf83b88802c423f83b6871da1e0653c-0000000000195efa-000593a2eaefe669.journal (128.0M).
Deleted archived journal /var/log/journal/2567a02e7d8d40ef836b2e565fa8cdd9/system@baf83b88802c423f83b6871da1e0653c-00000000001b53dd-000593a4cd02af07.journal (128.0M).
Deleted archived journal /var/log/journal/2567a02e7d8d40ef836b2e565fa8cdd9/system@baf83b88802c423f83b6871da1e0653c-00000000001d48cc-000593a6afa8199d.journal (120.0M).
Deleted archived journal /var/log/journal/2567a02e7d8d40ef836b2e565fa8cdd9/user-1000@760f0062619446688a8f56f0687c8c8b-00000000001ee8d5-000593a83fd715e5.journal (8.0M).
Vacuuming done, freed 1.5G of archived journals from /var/log/journal/2567a02e7d8d40ef836b2e565fa8cdd9.
```