### PR TITLE
Issue #115 Enable PV for registry volume

### DIFF
--- a/registry_pvc.yaml
+++ b/registry_pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: registry
+  namespace: openshift-image-registry
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+  selector:
+    matchLabels:
+      volume: "pv0001"

--- a/snc.sh
+++ b/snc.sh
@@ -226,6 +226,9 @@ ${OC} scale --replicas=0 deployment.apps/downloads -n openshift-console
 # Set default route for registry CRD from false to true.
 ${OC} patch config.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
 
+# Apply registry pvc to bound with pv0001
+${OC} apply -f registry_pvc.yaml
+
 # Delete the v1beta1.metrics.k8s.io apiservice since we are already scale down cluster wide monitioring.
 # Since this CRD block namespace deletion forever.
 ${OC} delete apiservice v1beta1.metrics.k8s.io

--- a/snc.sh
+++ b/snc.sh
@@ -50,7 +50,7 @@ metadata:
     volume: ${name}
 spec:
   capacity:
-    storage: 10Gi
+    storage: 100Gi
   accessModes:
     - ReadWriteOnce
     - ReadWriteMany


### PR DESCRIPTION
Currently `EmptyDir{}` is used as volume for registry which doesn't
able to persist the data from start => stop case.