### PR TITLE
Issue #117 Validate kubelet server cert also for expiration

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -198,8 +198,13 @@ create_pvs "${CRC_PV_DIR}" 30
 # Once it is finished, disable the CVO
 ${OC} scale --replicas=0 deployment --all -n openshift-cluster-version
 
+# Get the pod name associated with cluster-monitoring-operator deployment
+cmo_pod=$(${OC} get pod -l app=cluster-monitoring-operator -o jsonpath="{.items[0].metadata.name}" -n openshift-monitoring)
 # Disable the deployment/replicaset/statefulset config for openshift-monitoring namespace
 ${OC} scale --replicas=0 deployment --all -n openshift-monitoring
+# Wait till the cluster-monitoring-operator pod is deleted
+${OC} wait --for=delete pod/$cmo_pod --timeout=60s -n openshift-monitoring
+# Disable the statefulset for openshift-monitoring namespace
 ${OC} scale --replicas=0 statefulset --all -n openshift-monitoring
 
 # Delete the pods which are there in Complete state

--- a/snc.sh
+++ b/snc.sh
@@ -226,6 +226,9 @@ ${OC} scale --replicas=0 deployment.apps/downloads -n openshift-console
 # Set default route for registry CRD from false to true.
 ${OC} patch config.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
 
+# Set replica for cloud-credential-operator from 1 to 0
+${OC} scale --replicas=0 deployment --all -n openshift-cloud-credential-operator
+
 # Apply registry pvc to bound with pv0001
 ${OC} apply -f registry_pvc.yaml
 


### PR DESCRIPTION
It is possible that sometime client cert is rotated but server one is not or vice versa. We need to add check for both the certs.

```
$ ssh -i id_rsa_crc -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@192.168.126.11 -- sudo openssl x509 -checkend 2160000 -noout -in /var/lib/kubelet/pki/kubelet-client-current.pem
Certificate will not expire
$ ssh -i id_rsa_crc -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core@192.168.126.11 -- sudo openssl x509 -checkend 2160000 -noout -in /var/lib/kubelet/pki/kubelet-server-current.pem
Certificate will expire
```