### PR TITLE
Issue #115 Add pvc as registry storage.

### DIFF
--- a/registry_pvc.yaml
+++ b/registry_pvc.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: registry
+  name: crc-image-registry-storage	
   namespace: openshift-image-registry
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: 100Gi

--- a/snc.sh
+++ b/snc.sh
@@ -237,6 +237,11 @@ ${OC} scale --replicas=0 deployment --all -n openshift-cloud-credential-operator
 # Apply registry pvc to bound with pv0001
 ${OC} apply -f registry_pvc.yaml
 
+# Add registry storage to pvc
+${OC} patch config.imageregistry.operator.openshift.io/cluster --patch='[{"op": "add", "path": "/spec/storage/pvc", "value": {"claim": "crc-image-registry-storage"}}]' --type=json
+# Remove emptyDir as storage for registry
+${OC} patch config.imageregistry.operator.openshift.io/cluster --patch='[{"op": "remove", "path": "/spec/storage/emptyDir"}]' --type=json
+
 # Delete the v1beta1.metrics.k8s.io apiservice since we are already scale down cluster wide monitioring.
 # Since this CRD block namespace deletion forever.
 ${OC} delete apiservice v1beta1.metrics.k8s.io


### PR DESCRIPTION
This revert the 7c468bde commit since it is not persist during restart.
To have it properly we need to make the change to configs.imageregistry.operator.openshift.io
resources.

- https://docs.openshift.com/container-platform/4.2/registry/configuring-registry-storage/configuring-registry-storage-baremetal.html