### PR TITLE
Issue #127 Increase the timeout for kubelet-bootstrap-cred-manager pod termination

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -271,6 +271,6 @@ cert_pod=$(${OC} get pod -l k8s-app=kubelet-bootstrap-cred-manager -o jsonpath="
 # Remove the bootstrap-cred-manager daemonset
 ${OC} delete daemonset.apps/kubelet-bootstrap-cred-manager -n openshift-machine-config-operator
 # Wait till the cert pod is removed
-${OC} wait --for=delete pod/$cert_pod --timeout=60s -n openshift-machine-config-operator
+${OC} wait --for=delete pod/$cert_pod --timeout=120s -n openshift-machine-config-operator
 # Remove the cli image which was used for the bootstrap-cred-manager daemonset
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo crictl rmi quay.io/openshift/origin-cli:v4.0


### PR DESCRIPTION
Currently, the timeout is 60s which is not enough for kubelet-bootstrap-cred-manager pod
to terminated properly and this also lead to error of deleting the image.
we should increase it to 120s to be in safer side.

```
daemonset.apps "kubelet-bootstrap-cred-manager" deleted
error: timed out waiting for the condition
```