### PR TITLE
Issue #134 Fix partition logic for encrypted partitions

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -51,7 +51,7 @@ function create_qemu_image {
     ${QEMU_IMG} commit $destDir/${VM_PREFIX}-master-0
 
     # Check which partition is labeled as `root`
-    partition=$(${VIRT_FILESYSTEMS} -a $destDir/${VM_PREFIX}-base  -l | grep root | cut -f1 -d' ')
+    partition=$(${VIRT_FILESYSTEMS} -a $destDir/${VM_PREFIX}-base -l --partitions | sort -rk4 -n | sed -n 1p | cut -f1 -d' ')
 
     # Resize the image from the default 1+15GB to 1+30GB
     ${QEMU_IMG} create -o lazy_refcounts=on -f qcow2 $destDir/${CRC_VM_NAME}.qcow2 31G

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -61,18 +61,7 @@ function create_qemu_image {
             exit 1
     fi
 
-    # Remove immutable attribute for OpenShift 4.3+
-    guestfish -a $destDir/${CRC_VM_NAME}.qcow2 -m /dev/sda4 set-e2attrs / i clear:true
-
-    # TMPDIR must point at a directory with as much free space as the size of the image we want to sparsify
-    # Read limitation section of `man virt-sparsify`.
-    TMPDIR=$(pwd)/$destDir ${VIRT_SPARSIFY} -o lazy_refcounts=on $destDir/${CRC_VM_NAME}.qcow2 $destDir/${CRC_VM_NAME}_sparse.qcow2
-    rm -f $destDir/${CRC_VM_NAME}.qcow2
-    mv $destDir/${CRC_VM_NAME}_sparse.qcow2 $destDir/${CRC_VM_NAME}.qcow2
     rm -fr $destDir/.guestfs-*
-
-    # Set immutable attribute back for /dev/sda4
-    guestfish -a $destDir/${CRC_VM_NAME}.qcow2 -m /dev/sda4 set-e2attrs / i
 
     # Before using the created qcow2, check if it has lazy_refcounts set to true.
     ${QEMU_IMG} info ${destDir}/${CRC_VM_NAME}.qcow2 | grep "lazy refcounts: true" 2>&1 >/dev/null
@@ -200,7 +189,6 @@ BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
 JQ=${JQ:-jq}
 VIRT_RESIZE=${VIRT_RESIZE:-virt-resize}
 QEMU_IMG=${QEMU_IMG:-qemu-img}
-VIRT_SPARSIFY=${VIRT_SPARSIFY:-virt-sparsify}
 VIRT_FILESYSTEMS=${VIRT_FILESYSTEMS:-virt-filesystems}
 
 if [[ $# -ne 1 ]]; then


### PR DESCRIPTION
For an encrypted disk, virt-filesystem doesn't show all the partition
until specified. Also now there is no `root` label on partition so this logic
need to be changed.
```
$ virt-filesystems -a crc-ssnp7-base -l
Name       Type        VFS   Label       Size       Parent
/dev/sda1  filesystem  ext4  boot        402653184  -
/dev/sda2  filesystem  vfat  EFI-SYSTEM  133169152  -

$ virt-filesystems -a crc-ssnp7-base -l --partitions
Name       Type       MBR  Size         Parent
/dev/sda1  partition  -    402653184    /dev/sda
/dev/sda2  partition  -    133169152    /dev/sda
/dev/sda3  partition  -    1048576      /dev/sda
/dev/sda4  partition  -    16641932800  /dev/sda
```