### PR TITLE
Issue #139 Add a retry and wait time for `crictl rmp`

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -239,7 +239,7 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl stop kubelet
 
 # Remove all the pods from the VM
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo crictl stopp $(sudo crictl pods -q)'
-${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo crictl rmp $(sudo crictl pods -q)'
+${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'for i in {1..3}; do sudo crictl rmp $(sudo crictl pods -q) && break || sleep 2; done'
 
 # Remove pull secret from the VM
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rm -f /var/lib/kubelet/config.json'


### PR DESCRIPTION
Right now during the disk creation `crictl rmp` run just after `crictl stopp`
which fails with following errors if the containers are not stopped properly.

```
$ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_crc core@api.crc.testing -- 'sudo crictl rmp $(sudo crictl pods -q)'
Warning: Permanently added 'api.crc.testing,192.168.126.11' (ECDSA) to the list of known hosts.
time="2019-12-11T05:13:15Z" level=fatal msg="removing the pod sandbox \"8412e11d8371c2d12cc2866db64f5b4678c3a31980d4008c2e0fbeafb1c86b47\" failed: rpc error: code = Unknown desc = failed to remove pod sandbox 8412e11d8371c2d12cc2866db64f5b4678c3a31980d4008c2e0fbeafb1c86b47: unlinkat /var/run/containers/storage/overlay-containers/8412e11d8371c2d12cc2866db64f5b4678c3a31980d4008c2e0fbeafb1c86b47/userdata/shm: device or resource busy"
```