### PR TITLE
Issue #137 Remove unused images from container storage

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -271,6 +271,9 @@ ${OC} --config $1/auth/kubeconfig create clusterrolebinding developer --clusterr
 certImage=$(${OC} --config $1/auth/kubeconfig adm release info --image-for=cluster-kube-apiserver-operator)
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo podman tag $certImage openshift/cert-recovery
 
+# Remove unused images from container storage
+${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo crictl images -q | xargs -n 1 sudo crictl rmi 2>/dev/null'
+
 # Replace pull secret with a null json string '{}'
 ${OC} --config $1/auth/kubeconfig replace -f pull-secret.yaml
 


### PR DESCRIPTION
As part of CRC we disable some of operators like (monitoring/machine-config ..etc.) but
the images are always present on the node since there is no knob on installer side right now
to disable those operators from starting (iirc.) Now overall disk size is increases,
till 4.2 our final disk size was around 2GB but with 4.3 it is increasing around 3GB
and that is because all the other images are added as part of CVO payload.

crictl version used in the RHCOS is `0.1.0` which doesn't have fix
for kubernetes-sigs/cri-tools#399 one yet so
using kubernetes-sigs/cri-tools#399 (comment) as workaround.