### PR TITLE
Add rolebinding for developer user to be able to list installed operators

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -265,7 +265,9 @@ fi
 # Add a user developer:developer with htpasswd identity provider and give it sudoer role
 ${OC} --config $1/auth/kubeconfig create secret generic htpass-secret --from-literal=htpasswd=${DEVELOPER_USER_PASS} -n openshift-config
 ${OC} --config $1/auth/kubeconfig apply -f htpasswd_cr.yaml
+${OC} --config $1/auth/kubeconfig apply -f operator-view-clusterrole.yaml
 ${OC} --config $1/auth/kubeconfig create clusterrolebinding developer --clusterrole=sudoer --user=developer
+${OC} --config $1/auth/kubeconfig create clusterrolebinding developer-operator-view --clusterrole=operator-view --user=developer
 
 # Get cluster-kube-apiserver-operator image along with hash and tag it
 certImage=$(${OC} --config $1/auth/kubeconfig adm release info --image-for=cluster-kube-apiserver-operator)

--- a/operator-view-clusterrole.yaml
+++ b/operator-view-clusterrole.yaml
@@ -1,0 +1,18 @@
+# cluster role to view resources from api group operators.coreos.com
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: operator-view
+rules:
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - clusterserviceversions
+  - catalogsources
+  - installplans
+  - subscriptions
+  - operatorgroups
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
To view installed operators access to resources from operators.coreos.com
is needed, this patch adds a cluster role for this and binds it to the
developer user.

Related to: https://github.com/code-ready/crc/issues/1096