### PR TITLE
Update memory from 12GB to 14GB

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -234,7 +234,7 @@ ${OPENSHIFT_INSTALL} --dir ${INSTALL_DIR} create manifests || exit 1
 ${YQ} write --inplace ${INSTALL_DIR}/manifests/cluster-ingress-02-config.yml spec[domain] apps-${CRC_VM_NAME}.${BASE_DOMAIN}
 # Add master memory to 12 GB and 6 cpus 
 # This is only valid for openshift 4.3 onwards
-${YQ} write --inplace ${INSTALL_DIR}/openshift/99_openshift-cluster-api_master-machines-0.yaml spec.providerSpec.value[domainMemory] 12288
+${YQ} write --inplace ${INSTALL_DIR}/openshift/99_openshift-cluster-api_master-machines-0.yaml spec.providerSpec.value[domainMemory] 14336
 ${YQ} write --inplace ${INSTALL_DIR}/openshift/99_openshift-cluster-api_master-machines-0.yaml spec.providerSpec.value[domainVcpu] 6
 
 # Add codeReadyContainer as invoker to identify it with telemeter


### PR DESCRIPTION
In 4.3.8 looks like the cluster is taking almost full allocated memory
so to start the cluster in sane state we need to increase the memory
resource.