### PR TITLE
Add instance IP to metadata

### DIFF
--- a/crc-bundle-info.json.sample
+++ b/crc-bundle-info.json.sample
@@ -45,6 +45,8 @@
       # Disk image used by the node, the 'storage' object will contain more
       # details about its format
       "diskImage": "crc.qcow2"
+      # Internal IP for which etcd certs are valid
+      "internalIP": "192.168.126.11"
       # kernel command line of the node
       "kernelCmdLine": "BOOT_IMAGE=/ostree/rhcos-bf3b38268ddb2a2070dc587b361ce45c46a6f9e3606bbd3b5e15b2e6d3d47e5d/vmlinuz-4.18.0-80.1.2.el8_0.x86_64 console=tty0 console=ttyS0,115200n8 rootflags=defaults,prjquota rw root=UUID=a8fbdcb1-63ea-421e-8f6f-dac9cbbcc822 ostree=/ostree/boot.0/rhcos/bf3b38268ddb2a2070dc587b361ce45c46a6f9e3606bbd3b5e15b2e6d3d47e5d/0 coreos.oem.id=qemu ignition.platform.id=qemu"
       # initramfs file of the node

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -347,6 +347,9 @@ kernel_cmd_line=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'cat /proc/cm
 # SCP the vmlinuz/initramfs from VM to Host in provided folder.
 ${SCP} core@api.${CRC_VM_NAME}.${BASE_DOMAIN}:/boot/ostree/rhcos-${ostree_hash}/* $1
 
+# Add a dummy network interface with internalIP
+${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- "sudo nmcli conn add type dummy ifname eth10 con-name internalEtcd ip4 ${INTERNAL_IP}/24  && sudo nmcli conn up internalEtcd"
+
 # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1729603
 # TODO: Should be removed once latest podman available or the fix is backported.
 # Issue found in podman version 1.4.2-stable2 (podman-1.4.2-5.el8.x86_64)

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -350,6 +350,9 @@ ${SCP} core@api.${CRC_VM_NAME}.${BASE_DOMAIN}:/boot/ostree/rhcos-${ostree_hash}/
 # Add a dummy network interface with internalIP
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- "sudo nmcli conn add type dummy ifname eth10 con-name internalEtcd ip4 ${INTERNAL_IP}/24  && sudo nmcli conn up internalEtcd"
 
+# Add internalIP as node IP for kubelet systemd unit file
+${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- "sudo sed -i.back '/kubelet /a\      --node-ip="${INTERNAL_IP}" \\\' /etc/systemd/system/kubelet.service"
+
 # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1729603
 # TODO: Should be removed once latest podman available or the fix is backported.
 # Issue found in podman version 1.4.2-stable2 (podman-1.4.2-5.el8.x86_64)


### PR DESCRIPTION
From 4.4 release etcd certs are now created for
internal IP instead dns srv record like it used to, in case
of the libvirt the internal IP is same as VM ip.