### PR TITLE
Adding a 4.4 workaround note in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 - cd <directory_to_cloned_repo>
 - ./snc.sh
 
+> *Note for building a 4.4 image:* See https://github.com/code-ready/snc/wiki/Workaround-for-4.4--etcd-operator-addition.
+
 ## How to create disk image?
 - Once your `snc.sh` script run successfully.
 - You need to wait for around 30 mins till cluster settle.


### PR DESCRIPTION
I got stuck at building an image without this, and didn't realize that this note was in the wiki.  Adding to make it easier for others to notice.