### PR TITLE
Add VALID_CERT bool env to validate the cert

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -253,7 +253,10 @@ VM_PREFIX=${CRC_VM_NAME}-${random_string}
 # leeway regarding when we run the check with respect to rotation time
 if ! ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo openssl x509 -checkend 2160000 -noout -in /var/lib/kubelet/pki/kubelet-client-current.pem; then
     echo "Certs are not yet rotated to have 30 days validity"
-    exit 1;
+    # Only validate the cert expire time if SNC_VALIDATE_CERT is set to true
+    if [ "${SNC_VALIDATE_CERT:-true}" = true ]; then
+        exit 1;
+    fi
 fi
 
 # Add a user developer:developer with htpasswd identity provider and give it sudoer role

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -42,7 +42,9 @@ function sparsify {
 
     # Check which partition is labeled as `root`
     partition=$(${VIRT_FILESYSTEMS} -a $baseDir/$srcFile -l --partitions | sort -rk4 -n | sed -n 1p | cut -f1 -d' ')
-
+    
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1837765
+    export LIBGUESTFS_MEMSIZE=2048
     # Interact with guestfish directly
     # Starting with 4.3, the root partition is an encryption-ready luks partition
     # - virt-sparsify is not able to deal at all with this partition


### PR DESCRIPTION
In the CI environment we don't really need to validate the cluster
kubelet cert and also current cert rotation method is not work properly
so with this env we can choose to validate or not the cluster certs.