### PR TITLE
Pin master to openshift release candidate

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -26,7 +26,7 @@ else
     if test -n "${OPENSHIFT_RELEASE_VERSION}"; then
         echo "Using release ${OPENSHIFT_RELEASE_VERSION} from local Git tags"
     else
-        OPENSHIFT_RELEASE_VERSION="$(curl -L "${MIRROR}"/latest/release.txt | sed -n 's/^ *Version: *//p')"
+        OPENSHIFT_RELEASE_VERSION="$(curl -L "${MIRROR}"/candidate/release.txt | sed -n 's/^ *Version: *//p')"
         if test -n "${OPENSHIFT_RELEASE_VERSION}"; then
             echo "Using release ${OPENSHIFT_RELEASE_VERSION} from the latest mirror"
         else


### PR DESCRIPTION
master was pointing to 4.4.x. It's now 4.5.x.