### PR TITLE
Use threads option for xz compression

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -380,7 +380,7 @@ create_qemu_image $libvirtDestDir
 
 copy_additional_files $1 $libvirtDestDir
 
-tar cJSf $libvirtDestDir.$crcBundleSuffix $libvirtDestDir
+tar cSf - $libvirtDestDir | xz --threads=0 >$libvirtDestDir.$crcBundleSuffix
 
 # HyperKit image generation
 # This must be done after the generation of libvirt image as it reuse some of
@@ -389,7 +389,7 @@ hyperkitDestDir="crc_hyperkit_${destDirSuffix}"
 mkdir $hyperkitDestDir
 generate_hyperkit_directory $libvirtDestDir $hyperkitDestDir $1
 
-tar cJSf $hyperkitDestDir.$crcBundleSuffix $hyperkitDestDir
+tar cSf - $hyperkitDestDir | xz --threads=0 >$hyperkitDestDir.$crcBundleSuffix
 
 # HyperV image generation
 #
@@ -399,4 +399,4 @@ hypervDestDir="crc_hyperv_${destDirSuffix}"
 mkdir $hypervDestDir
 generate_hyperv_directory $libvirtDestDir $hypervDestDir
 
-tar cJSf $hypervDestDir.$crcBundleSuffix $hypervDestDir
+tar cSf - $hypervDestDir | xz --threads=0 >$hypervDestDir.$crcBundleSuffix


### PR DESCRIPTION
Using the threads option for xz we can reduce the bundle creation
time significantly. This will also help us to stop timeout for CI.
```
$ time xz --keep --threads=0 crc.qcow2
real    4m36.255s
user    54m17.698s
sys     0m3.416s

$ time xz --keep crc.qcow2
real    34m48.959s
user    34m46.237s
sys     0m2.710s

$ time xz --threads=0 crc_libvirt_4.4.8.tar
real	15m8.081s
user	107m18.482s
sys	0m18.774s
```