### PR TITLE
[WIP] move cvo override between `create manifest` and `create cluster`

### DIFF
--- a/cvo_override.yaml
+++ b/cvo_override.yaml
@@ -13,11 +13,6 @@
     unmanaged: true
   - kind: Deployment
     group: apps/v1
-    name: machine-api-operator
-    namespace: openshift-machine-api
-    unmanaged: true
-  - kind: Deployment
-    group: apps/v1
     name: cluster-autoscaler-operator
     namespace: openshift-machine-api
     unmanaged: true

--- a/cvo_override.yaml
+++ b/cvo_override.yaml
@@ -8,11 +8,6 @@
     unmanaged: true
   - kind: Deployment
     group: apps/v1
-    name: machine-config-operator
-    namespace: openshift-machine-config-operator
-    unmanaged: true
-  - kind: Deployment
-    group: apps/v1
     name: etcd-quorum-guard
     namespace: openshift-machine-config-operator
     unmanaged: true

--- a/cvo_override.yaml
+++ b/cvo_override.yaml
@@ -256,3 +256,53 @@
     name: kube-scheduler
     namespace: openshift-kube-scheduler
     unmanaged: true
+  - kind: PrometheusRule
+    group: monitoring.coreos.com/v1
+    name: kube-apiserver
+    namespace: openshift-kube-apiserver
+    unmanaged: true
+  - kind: ClusterOperator
+    group: config.openshift.io/v1
+    name: cloud-credential
+    namespace: ""
+    unmanaged: true
+  - kind: ClusterOperator
+    group: config.openshift.io/v1
+    name: cluster-autoscaler
+    namespace: ""
+    unmanaged: true
+  - kind: ClusterOperator
+    group: config.openshift.io/v1
+    name: csi-snapshot-controller
+    namespace: ""
+    unmanaged: true
+  - kind: ClusterOperator
+    group: config.openshift.io/v1
+    name: insights
+    namespace: ""
+    unmanaged: true
+  - kind: ClusterOperator
+    group: config.openshift.io/v1
+    name: kube-storage-version-migrator
+    namespace: ""
+    unmanaged: true
+  - kind: ClusterOperator
+    group: config.openshift.io/v1
+    name: monitoring
+    namespace: ""
+    unmanaged: true
+  - kind: ClusterOperator
+    group: config.openshift.io/v1
+    name: storage
+    namespace: ""
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: insights-operator
+    namespace: openshift-insights
+    unmanaged: true
+  - kind: PrometheusRule
+    group: monitoring.coreos.com/v1
+    name: cluster-autoscaler-operator-rules
+    namespace: openshift-machine-api
+    unmanaged: true

--- a/cvo_override.yaml
+++ b/cvo_override.yaml
@@ -51,3 +51,213 @@
     name: kube-storage-version-migrator-operator
     namespace: openshift-kube-storage-version-migrator-operator
     unmanaged: true
+  - kind: PrometheusRule
+    group: monitoring.coreos.com/v1
+    name: cloud-credential-operator-alerts
+    namespace: openshift-cloud-credential-operator
+    unmanaged: true
+  - kind: PrometheusRule
+    group: monitoring.coreos.com/v1
+    name: samples-operator-alerts
+    namespace: openshift-cluster-samples-operator
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: openshift-apiserver-operator
+    namespace: openshift-apiserver-operator
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: authentication-operator
+    namespace: openshift-authentication-operator
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: cluster-machine-approver
+    namespace: openshift-cluster-machine-approver
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: cluster-version-operator
+    namespace: openshift-cluster-version
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: config-operator
+    namespace: openshift-config-operator
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: console-operator
+    namespace: openshift-console-operator
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: openshift-controller-manager-operator
+    namespace: openshift-controller-manager-operator
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: dns-operator
+    namespace: openshift-dns-operator
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: etcd-operator
+    namespace: openshift-etcd-operator
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: image-registry
+    namespace: openshift-image-registry
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: ingress-operator
+    namespace: openshift-ingress-operator
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: kube-apiserver-operator
+    namespace: openshift-kube-apiserver-operator
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: kube-controller-manager-operator
+    namespace: openshift-kube-controller-manager-operator
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: kube-scheduler-operator
+    namespace: openshift-kube-scheduler-operator
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: cluster-autoscaler-operator
+    namespace: openshift-machine-api
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: machine-api-operator
+    namespace: openshift-machine-api
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: machine-config-daemon
+    namespace: openshift-machine-config-operator
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: marketplace-operator
+    namespace: openshift-marketplace
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: olm-operator
+    namespace: openshift-operator-lifecycle-manager
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: service-ca-operator
+    namespace: openshift-service-ca-operator
+    unmanaged: true
+  - kind: PrometheusRule
+    group: monitoring.coreos.com/v1
+    name: machineapprover-rules
+    namespace: openshift-cluster-machine-approver
+    unmanaged: true
+  - kind: PrometheusRule
+    group: monitoring.coreos.com/v1
+    name: cluster-version-operator
+    namespace: openshift-cluster-version
+    unmanaged: true
+  - kind: PrometheusRule
+    group: monitoring.coreos.com/v1
+    name: image-registry-operator-alerts
+    namespace: openshift-image-registry
+    unmanaged: true
+  - kind: PrometheusRule
+    group: monitoring.coreos.com/v1
+    name: kube-apiserver-operator
+    namespace: openshift-kube-apiserver-operator
+    unmanaged: true
+  - kind: PrometheusRule
+    group: monitoring.coreos.com/v1
+    name: kube-scheduler-operator
+    namespace: openshift-kube-scheduler-operator
+    unmanaged: true
+  - kind: PrometheusRule
+    group: monitoring.coreos.com/v1
+    name: machine-api-operator-prometheus-rules
+    namespace: openshift-machine-api
+    unmanaged: true
+  - kind: PrometheusRule
+    group: monitoring.coreos.com/v1
+    name: machine-config-daemon
+    namespace: openshift-machine-config-operator
+    unmanaged: true
+  - kind: PrometheusRule
+    group: monitoring.coreos.com/v1
+    name: marketplace-alert-rules
+    namespace: openshift-marketplace
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: openshift-apiserver
+    namespace: openshift-apiserver
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: oauth-openshift
+    namespace: openshift-authentication
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: cloud-credential-operator
+    namespace: openshift-cloud-credential-operator
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: cluster-samples-operator
+    namespace: openshift-cluster-samples-operator
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: openshift-controller-manager
+    namespace: openshift-controller-manager
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: image-registry-operator
+    namespace: openshift-image-registry
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: kube-controller-manager
+    namespace: openshift-kube-controller-manager
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: catalog-operator
+    namespace: openshift-operator-lifecycle-manager
+    unmanaged: true
+  - kind: PrometheusRule
+    group: monitoring.coreos.com/v1
+    name: kube-controller-manager-operator
+    namespace: openshift-kube-controller-manager-operator
+    unmanaged: true
+  - kind: PrometheusRule
+    group: monitoring.coreos.com/v1
+    name: olm-alert-rules
+    namespace: openshift-operator-lifecycle-manager
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: kube-apiserver
+    namespace: openshift-kube-apiserver
+    unmanaged: true
+  - kind: ServiceMonitor
+    group: monitoring.coreos.com/v1
+    name: kube-scheduler
+    namespace: openshift-kube-scheduler
+    unmanaged: true

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+  - crc-tmp-install-data/manifests/cvo-overrides.yaml
+patchesJson6902:
+  - target:
+      group: config.openshift.io
+      version: v1
+      kind: ClusterVersion
+      name: version
+    path: cvo_override.yaml

--- a/snc.sh
+++ b/snc.sh
@@ -367,42 +367,10 @@ create_json_description
 # Create persistent volumes
 create_pvs "${CRC_PV_DIR}" 30
 
-# Clean-up 'openshift-monitoring' namespace
-delete_operator "deployment/cluster-monitoring-operator" "openshift-monitoring" "app=cluster-monitoring-operator"
-delete_operator "deployment/prometheus-operator" "openshift-monitoring" "app.kubernetes.io/name=prometheus-operator"
-delete_operator "deployment/prometheus-adapter" "openshift-monitoring" "name=prometheus-adapter"
-delete_operator "statefulset/alertmanager-main" "openshift-monitoring" "app=alertmanager"
-${OC} delete statefulset,deployment,daemonset --all -n openshift-monitoring
-
 # Delete the pods which are there in Complete state
 ${OC} delete pods -l 'app in (installer, pruner)' -n openshift-kube-apiserver
 ${OC} delete pods -l 'app in (installer, pruner)' -n openshift-kube-scheduler
 ${OC} delete pods -l 'app in (installer, pruner)' -n openshift-kube-controller-manager
-
-# Clean-up 'openshift-machine-api' namespace
-delete_operator "deployment/machine-api-operator" "openshift-machine-api" "k8s-app=machine-api-operator"
-${OC} delete statefulset,deployment,daemonset --all -n openshift-machine-api
-
-# Clean-up 'openshift-machine-config-operator' namespace
-delete_operator "deployment/machine-config-operator" "openshift-machine-config-operator" "k8s-app=machine-config-operator"
-${OC} delete statefulset,deployment,daemonset --all -n openshift-machine-config-operator
-
-# Clean-up 'openshift-insights' namespace
-${OC} delete statefulset,deployment,daemonset --all -n openshift-insights
-
-# Clean-up 'openshift-cloud-credential-operator' namespace
-${OC} delete statefulset,deployment,daemonset --all -n openshift-cloud-credential-operator
-
-# Clean-up 'openshift-cluster-storage-operator' namespace
-delete_operator "deployment.apps/csi-snapshot-controller-operator" "openshift-cluster-storage-operator" "app=csi-snapshot-controller-operator"
-${OC} delete statefulset,deployment,daemonset --all -n openshift-cluster-storage-operator
-
-# Clean-up 'openshift-kube-storage-version-migrator-operator' namespace
-${OC} delete statefulset,deployment,daemonset --all -n openshift-kube-storage-version-migrator-operator
-
-# Delete the v1beta1.metrics.k8s.io apiservice since we are already scale down cluster wide monitioring.
-# Since this CRD block namespace deletion forever.
-${OC} delete apiservice v1beta1.metrics.k8s.io
 
 # Scale route deployment from 2 to 1
 ${OC} scale --replicas=1 ingresscontroller/default -n openshift-ingress-operator


### PR DESCRIPTION
It works but I'm not sure this is the right path to follow. 

Pros:
* Unwanted operators never run
* It's what we aim with cluster profile
* Simpler snc script

Cons:
* Still leave broken contents (ns with services but not the operator, etc.)
* CRDs created by operators are not present (PrometheusRule and ServiceMonitor for example)
* It doesn't speed up snc
* Override list is hard to maintain.