### PR TITLE
Revert "Use raw image on macos"

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -155,20 +155,15 @@ function generate_hyperkit_directory {
     cp $srcDir/kubeadmin-password $destDir/
     cp $srcDir/kubeconfig $destDir/
     cp $srcDir/id_rsa_crc $destDir/
-    ${QEMU_IMG} convert -f qcow2 -O raw $srcDir/${CRC_VM_NAME}.qcow2 $destDir/${CRC_VM_NAME}.img
+    cp $srcDir/${CRC_VM_NAME}.qcow2 $destDir/
     cp $tmpDir/vmlinuz-${kernel_release} $destDir/
     cp $tmpDir/initramfs-${kernel_release}.img $destDir/
 
     # Update the bundle metadata info
     cat $srcDir/crc-bundle-info.json \
-        | ${JQ} ".nodes[0].diskImage = \"${CRC_VM_NAME}.img\"" \
         | ${JQ} ".nodes[0].kernel = \"vmlinuz-${kernel_release}\"" \
         | ${JQ} ".nodes[0].initramfs = \"initramfs-${kernel_release}.img\"" \
         | ${JQ} ".nodes[0].kernelCmdLine = \"${kernel_cmd_line}\"" \
-        | ${JQ} ".storage.diskImages[0].name = \"${CRC_VM_NAME}.img\"" \
-        | ${JQ} '.storage.diskImages[0].format = "raw"' \
-        | ${JQ} ".storage.diskImages[0].size = \"${diskSize}\"" \
-        | ${JQ} ".storage.diskImages[0].sha256sum = \"${diskSha256Sum}\"" \
         | ${JQ} '.driverInfo.name = "hyperkit"' \
         >$destDir/crc-bundle-info.json
 }


### PR DESCRIPTION
This needs more work on the crc side, let's revert this for now as next
crc release is fairly close.

What does not work:

- Image size is incorrect in the metadata file:
ERRO Invalid bundle disk image '/Users/teuf/.crc/cache/crc_hyperkit_4.5.0-rc.7/crc.img', Expected size 8524267520 Got 33285996544

- crc does not handle correctly sparse files:
$ du -sh ~/.crc/cache/crc_hyperkit_4.5.0-rc.7/
31G    /Users/teuf/.crc/cache/crc_hyperkit_4.5.0-rc.7/
(tar JSxvf ../crc_hyperkit_4.5.0-rc.7.crcbundle uncompresses to a 12G file)

- The machine driver does hardcodes that we are using a qcow2 file
https://github.com/code-ready/machine-driver-hyperkit/blob/master/pkg/hyperkit/driver.go#L228-L234

This reverts commit 8d997d97405b8004cbf1f1a71771a59adf68758e.