### PR TITLE
Enable Multi-Architecture Support

### DIFF
--- a/install-config.yaml
+++ b/install-config.yaml
@@ -3,13 +3,13 @@
 apiVersion: v1
 baseDomain: testing
 compute:
-- architecture: amd64
+- architecture: 
   hyperthreading: Enabled
   name: worker
   platform: {}
   replicas: 1
 controlPlane:
-  architecture: amd64
+  architecture: 
   hyperthreading: Enabled
   name: master
   platform: {}


### PR DESCRIPTION
Enable support for both ppc64le and s390x using what’s available from the mirror. Creates a global $ARCH variable and then download proper Openshift binaries from the official mirror. Remove the local arch variable added by preflight check introduced from commit b03abd4. Use proper arch name for yq binary - x86_64 is labeled as amd64.  Also includes the extra step in README to change value of architecture key in install-config.yaml.

@Prashanth684
