### PR TITLE
Update the mirror url to use latest-4.5

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -33,7 +33,7 @@ else
     if test -n "${OPENSHIFT_RELEASE_VERSION}"; then
         echo "Using release ${OPENSHIFT_RELEASE_VERSION} from local Git tags"
     else
-        OPENSHIFT_RELEASE_VERSION="$(curl -L "${MIRROR}"/candidate/release.txt | sed -n 's/^ *Version: *//p')"
+        OPENSHIFT_RELEASE_VERSION="$(curl -L "${MIRROR}"/latest-4.5/release.txt | sed -n 's/^ *Version: *//p')"
         if test -n "${OPENSHIFT_RELEASE_VERSION}"; then
             echo "Using release ${OPENSHIFT_RELEASE_VERSION} from the latest mirror"
         else


### PR DESCRIPTION
We started using candidate for 4.5 because that time latest link
was not available and now it is so switching to latest so our CI
also can test what is comming in latest-4.5 side.