### PR TITLE
Use jsonpath to get the csr resource name

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -225,7 +225,7 @@ function renew_certificates() {
 
     # Wait until bootstrap csr request is generated.
     until ${OC} get csr | grep Pending; do echo 'Waiting for first CSR request.'; sleep 2; done
-    ${OC} get csr -oname | xargs ${OC} adm certificate approve
+    ${OC} get csr -ojsonpath='{.items[*].metadata.name}' | xargs ${OC} adm certificate approve
 
     delete_operator "daemonset/kubelet-bootstrap-cred-manager" "openshift-machine-config-operator" "k8s-app=kubelet-bootstrap-cred-manager"
 }


### PR DESCRIPTION
The current method fails on the installer master.

```
$ oc get csr -oname
certificatesigningrequest.certificates.k8s.io/csr-54rz4
certificatesigningrequest.certificates.k8s.io/csr-7rjpg
certificatesigningrequest.certificates.k8s.io/csr-chcck
certificatesigningrequest.certificates.k8s.io/csr-k88s4
certificatesigningrequest.certificates.k8s.io/csr-pmsqw

$ oc get csr -oname | xargs oc adm certificate approve
No resources found
no kind "CertificateSigningRequest" is registered for version "certificates.k8s.io/v1" in scheme "k8s.io/kubectl/pkg/scheme/scheme.go:28"
no kind "CertificateSigningRequest" is registered for version "certificates.k8s.io/v1" in scheme "k8s.io/kubectl/pkg/scheme/scheme.go:28"
no kind "CertificateSigningRequest" is registered for version "certificates.k8s.io/v1" in scheme "k8s.io/kubectl/pkg/scheme/scheme.go:28"
no kind "CertificateSigningRequest" is registered for version "certificates.k8s.io/v1" in scheme "k8s.io/kubectl/pkg/scheme/scheme.go:28"
no kind "CertificateSigningRequest" is registered for version "certificates.k8s.io/v1" in scheme "k8s.io/kubectl/pkg/scheme/scheme.go:28"

$ oc get csr -ojsonpath='{.items[*].metadata.name}' | xargs oc adm certificate approve
certificatesigningrequest.certificates.k8s.io/csr-54rz4 approved
certificatesigningrequest.certificates.k8s.io/csr-7rjpg approved
certificatesigningrequest.certificates.k8s.io/csr-8chcc approved
certificatesigningrequest.certificates.k8s.io/csr-chcck approved
certificatesigningrequest.certificates.k8s.io/csr-k88s4 approved
certificatesigningrequest.certificates.k8s.io/csr-pmsqw approved
```