### PR TITLE
Use oc binary from the payload instead user provided

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -297,6 +297,15 @@ if test -z ${OPENSHIFT_INSTALL-}; then
     OPENSHIFT_INSTALL=./openshift-install
 fi
 
+# Extract oc binary from the payload and use it for all following operations
+if ! test -f oc; then
+    echo "Extracting oc binary from OpenShift payload image"
+    oc_image=$(${OC} adm release -a ${OPENSHIFT_PULL_SECRET_PATH} info ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} --image-for=cli-artifacts)
+    ${OC} image -a ${OPENSHIFT_PULL_SECRET_PATH} extract ${oc_image} --confirm --path /usr/bin/oc:.
+    chmod +x oc
+    OC=./oc
+fi
+
 # Allow to disable debug by setting SNC_OPENSHIFT_INSTALL_NO_DEBUG in the environment
 if test -z "${SNC_OPENSHIFT_INSTALL_NO_DEBUG-}"; then
         OPENSHIFT_INSTALL_EXTRA_ARGS="--log-level debug"


### PR DESCRIPTION
If user is using older version of oc binary then some of the
functionality doesn't work as expected due to server and client
mismatch.

```
$ oc adm certificate approve csr-chcck
No resources found
error: no kind "CertificateSigningRequest" is registered for version "certificates.k8s.io/v1" in scheme "k8s.io/kubectl/pkg/scheme/scheme.go:28"
```