### PR TITLE
Copy kubeconfig file to the VM

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -315,6 +315,10 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rpm-ostree install /home/
 # Remove the packages from VM
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- rm -fr /home/core/packages
 
+# SCP the kubeconfig file to VM
+${SCP} $1/auth/kubeconfig core@api.${CRC_VM_NAME}.${BASE_DOMAIN}:/home/core/
+${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo mv /home/core/kubeconfig /opt/'
+
 # Shutdown and Start the VM after installing the hyperV daemon packages.
 # This is required to get the latest ostree layer which have those installed packages.
 sudo virsh shutdown ${VM_PREFIX}-master-0


### PR DESCRIPTION
Right now in crc we copy the kubeconfig file from host to VM which
is used to execute oc commands from the VM, this commit will make
sure we do it as part of disk creation so that we don't need to do
it on crc side.