### PR TITLE
Kill the child process when main snc process exit

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -5,6 +5,9 @@ set -exuo pipefail
 export LC_ALL=C
 export LANG=C
 
+# kill all the child processes for this script when it exits
+trap 'kill -9 $(jobs -p) || true' EXIT
+
 INSTALL_DIR=crc-tmp-install-data
 JQ=${JQ:-jq}
 OC=${OC:-oc}


### PR DESCRIPTION
Currently our etcd hack function is always running if the snc script
exit before bootstrap, this patch will make sure that as soon as snc
script exit then it's child process also exit (in our case it's etcd hack)