### PR TITLE
Add OKD compatibility to snc for building CRC for OKD bundles

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -9,7 +9,7 @@ SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_c
 SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_crc"
 OC=${OC:-oc}
 DEVELOPER_USER_PASS='developer:$2y$05$paX6Xc9AiLa6VT7qr2VvB.Qi.GJsaqS80TR3Kb78FEIlIL0YyBuyS'
-BASE_OS=${BASE_OS:rhcos}
+BASE_OS=${BASE_OS:-rhcos}
 
 function get_dest_dir {
     if [ ${OPENSHIFT_VERSION} != "" ]; then

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+OPENSHIFT_VERSION=4.5.0-0.okd-2020-08-12-020541
+
 export LC_ALL=C
 export LANG=C
 
@@ -58,8 +60,7 @@ function sparsify {
     guestfish --remote <<EOF
 add-drive $baseDir/$srcFile
 run
-luks-open $partition coreos-root
-mount /dev/mapper/coreos-root /
+mount $partition /
 zero-free-space /boot/
 EOF
     if [ $? -ne 0 ]; then
@@ -336,7 +337,7 @@ until ping -c1 api.${CRC_VM_NAME}.${BASE_DOMAIN} >/dev/null 2>&1; do
 done
 
 # Get the rhcos ostree Hash ID
-ostree_hash=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'cat /proc/cmdline | grep -oP "(?<=rhcos-).*(?=/vmlinuz)"')
+ostree_hash=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'cat /proc/cmdline | grep -oP "(?<=fedora-coreos-).*(?=/vmlinuz)"')
 
 # Get the rhcos kernel release
 kernel_release=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'uname -r')
@@ -345,7 +346,7 @@ kernel_release=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'uname -r')
 kernel_cmd_line=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'cat /proc/cmdline')
 
 # SCP the vmlinuz/initramfs from VM to Host in provided folder.
-${SCP} core@api.${CRC_VM_NAME}.${BASE_DOMAIN}:/boot/ostree/rhcos-${ostree_hash}/* $1
+${SCP} core@api.${CRC_VM_NAME}.${BASE_DOMAIN}:/boot/ostree/fedora-coreos-${ostree_hash}/* $1
 
 # Add a dummy network interface with internalIP
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- "sudo nmcli conn add type dummy ifname eth10 con-name internalEtcd ip4 ${INTERNAL_IP}/24  && sudo nmcli conn up internalEtcd"

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -56,12 +56,24 @@ function sparsify {
             exit 1
     fi
 
-    guestfish --remote <<EOF
+    if [[ ${BASE_OS} == "rhcos" ]]
+    then
+        guestfish --remote <<EOF
+add-drive $baseDir/$srcFile
+run
+luks-open $partition coreos-root
+mount /dev/mapper/coreos-root /
+zero-free-space /boot/
+EOF
+    else
+        guestfish --remote <<EOF
 add-drive $baseDir/$srcFile
 run
 mount $partition /
 zero-free-space /boot/
 EOF
+    fi
+    
     if [ $? -ne 0 ]; then
             echo "Failed to sparsify $baseDir/$srcFile, aborting"
             exit 1

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-OPENSHIFT_VERSION=4.5.0-0.okd-2020-08-12-020541
-
 export LC_ALL=C
 export LANG=C
 
@@ -11,6 +9,7 @@ SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_c
 SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_crc"
 OC=${OC:-oc}
 DEVELOPER_USER_PASS='developer:$2y$05$paX6Xc9AiLa6VT7qr2VvB.Qi.GJsaqS80TR3Kb78FEIlIL0YyBuyS'
+BASE_OS=${BASE_OS:rhcos}
 
 function get_dest_dir {
     if [ ${OPENSHIFT_VERSION} != "" ]; then
@@ -337,7 +336,7 @@ until ping -c1 api.${CRC_VM_NAME}.${BASE_DOMAIN} >/dev/null 2>&1; do
 done
 
 # Get the rhcos ostree Hash ID
-ostree_hash=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'cat /proc/cmdline | grep -oP "(?<=fedora-coreos-).*(?=/vmlinuz)"')
+ostree_hash=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- "cat /proc/cmdline | grep -oP \"(?<=${BASE_OS}-).*(?=/vmlinuz)\"")
 
 # Get the rhcos kernel release
 kernel_release=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'uname -r')
@@ -346,7 +345,7 @@ kernel_release=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'uname -r')
 kernel_cmd_line=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'cat /proc/cmdline')
 
 # SCP the vmlinuz/initramfs from VM to Host in provided folder.
-${SCP} core@api.${CRC_VM_NAME}.${BASE_DOMAIN}:/boot/ostree/fedora-coreos-${ostree_hash}/* $1
+${SCP} core@api.${CRC_VM_NAME}.${BASE_DOMAIN}:/boot/ostree/${BASE_OS}-${ostree_hash}/* $1
 
 # Add a dummy network interface with internalIP
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- "sudo nmcli conn add type dummy ifname eth10 con-name internalEtcd ip4 ${INTERNAL_IP}/24  && sudo nmcli conn up internalEtcd"


### PR DESCRIPTION
This pull request is to satisfy:

https://github.com/code-ready/crc/issues/977
https://github.com/code-ready/snc/issues/212

I see that there is an existing Pull Request that might pre-empt this one: https://github.com/code-ready/snc/pull/216

These changes to `createdisk.sh` are similar.  I made the modifications so that the build of `snc` for `OCP` should not require any changes.

To build `snc` for `OKD` you will set the following ENV vars: (For example)

```bash
export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE="quay.io/openshift/okd:4.5.0-0.okd-2020-08-12-020541"
export OPENSHIFT_VERSION=4.5.0-0.okd-2020-08-12-020541
export BUNDLE_VERSION=${OPENSHIFT_VERSION}                                  # This is for building crc
export MIRROR=https://github.com/openshift/okd/releases/download     # Also used by crc 
export OPENSHIFT_PULL_SECRET_PATH="/tmp/pull_secret.json"
export BASE_OS=fedora-coreos
```

The pull secret is fake:

```bash
cat << EOF > /tmp/pull_secret.json
{"auths":{"fake":{"auth": "Zm9vOmJhcgo="}}}
EOF
```

In `createdisk.sh`, BASE_OS defaults to `rhcos`.   Otherwise, it is used to distinguish between `rhcos` and `fedora-coreos` for disk image logic.

The logic for `guestfish` is:

```bash
    if [[ ${BASE_OS} == "rhcos" ]]
    then
        guestfish --remote <<EOF
add-drive $baseDir/$srcFile
run
luks-open $partition coreos-root
mount /dev/mapper/coreos-root /
zero-free-space /boot/
EOF
    else
        guestfish --remote <<EOF
add-drive $baseDir/$srcFile
run
mount $partition /
zero-free-space /boot/
EOF
    fi
```