### PR TITLE
Enable creating SNC for OKD 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,28 @@ $ export KUBECONFIG=<directory_to_cloned_repo>/crc-tmp-install-data/auth/kubecon
 $ kubectl get pods --all-namespaces
 ```
 
+## Building SNC for OKD 4
+- Before running `./snc.sh`, you need to create a pull secret file, and set a couple of environment variables to override the default behavior.
+- Select the OKD 4 release that you want to build from: [https://origin-release.apps.ci.l2s4.p1.openshiftapps.com](https://origin-release.apps.ci.l2s4.p1.openshiftapps.com)
+- For example, to build release: 4.5.0-0.okd-2020-08-12-020541
+
+```bash
+# Create a pull secret file
+
+cat << EOF > /tmp/pull_secret.json
+{"auths":{"fake":{"auth": "Zm9vOmJhcgo="}}}
+EOF
+
+# Set environment for OKD build
+export OKD_VERSION=4.5.0-0.okd-2020-08-12-020541
+export OPENSHIFT_PULL_SECRET_PATH="/tmp/pull_secret.json"
+
+# Build the Single Node cluster
+./snc.sh
+```
+
+- When the build is complete, create the disk image as described above.
+
 ## Troubleshooting
 
 OpenShift installer will create 2 VMs. It is sometimes useful to ssh inside the VMs.

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -9,6 +9,17 @@ SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_c
 SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_crc"
 OC=${OC:-oc}
 DEVELOPER_USER_PASS='developer:$2y$05$paX6Xc9AiLa6VT7qr2VvB.Qi.GJsaqS80TR3Kb78FEIlIL0YyBuyS'
+# If the user set OKD_VERSION in the environment, then use it to override OPENSHIFT_VERSION, set BASE_OS, and set USE_LUKS
+# Unless, those variables are explicitly set as well.
+OKD_VERSION=${OKD_VERSION:-none}
+if [[ ${OKD_VERSION} != "none" ]]
+then
+    OPENSHIFT_VERSION=${OKD_VERSION}
+    BASE_OS=fedora-coreos
+    USE_LUKS=false
+fi
+BASE_OS=${BASE_OS:-rhcos}
+USE_LUKS=${USE_LUKS:-true}
 
 function get_dest_dir {
     if [ ${OPENSHIFT_VERSION} != "" ]; then
@@ -58,10 +69,19 @@ function sparsify {
     guestfish --remote <<EOF
 add-drive $baseDir/$srcFile
 run
+EOF
+
+    if [[ ${USE_LUKS} == "true" ]]
+    then
+        guestfish --remote <<EOF
 luks-open $partition coreos-root
 mount /dev/mapper/coreos-root /
-zero-free-space /boot/
 EOF
+    else
+        guestfish --remote mount $partition /
+    fi
+
+    guestfish --remote zero-free-space /boot/
     if [ $? -ne 0 ]; then
             echo "Failed to sparsify $baseDir/$srcFile, aborting"
             exit 1
@@ -336,7 +356,7 @@ until ping -c1 api.${CRC_VM_NAME}.${BASE_DOMAIN} >/dev/null 2>&1; do
 done
 
 # Get the rhcos ostree Hash ID
-ostree_hash=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'cat /proc/cmdline | grep -oP "(?<=rhcos-).*(?=/vmlinuz)"')
+ostree_hash=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- "cat /proc/cmdline | grep -oP \"(?<=${BASE_OS}-).*(?=/vmlinuz)\"")
 
 # Get the rhcos kernel release
 kernel_release=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'uname -r')
@@ -345,7 +365,7 @@ kernel_release=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'uname -r')
 kernel_cmd_line=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'cat /proc/cmdline')
 
 # SCP the vmlinuz/initramfs from VM to Host in provided folder.
-${SCP} core@api.${CRC_VM_NAME}.${BASE_DOMAIN}:/boot/ostree/rhcos-${ostree_hash}/* $1
+${SCP} core@api.${CRC_VM_NAME}.${BASE_DOMAIN}:/boot/ostree/${BASE_OS}-${ostree_hash}/* $1
 
 # Add a dummy network interface with internalIP
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- "sudo nmcli conn add type dummy ifname eth10 con-name internalEtcd ip4 ${INTERNAL_IP}/24  && sudo nmcli conn up internalEtcd"

--- a/snc.sh
+++ b/snc.sh
@@ -8,6 +8,16 @@ export LANG=C
 # kill all the child processes for this script when it exits
 trap 'kill -9 $(jobs -p) || true' EXIT
 
+# If the user set OKD_VERSION in the environment, then use it to override OPENSHIFT_VERSION, MIRROR, and OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE
+# Unless, those variables are explicitly set as well.
+OKD_VERSION=${OKD_VERSION:-none}
+if [[ ${OKD_VERSION} != "none" ]]
+then
+    OPENSHIFT_VERSION=${OKD_VERSION}
+    MIRROR=${MIRROR:-https://github.com/openshift/okd/releases/download}
+    OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE:-quay.io/openshift/okd:${OPENSHIFT_VERSION}}
+fi
+
 INSTALL_DIR=crc-tmp-install-data
 JQ=${JQ:-jq}
 OC=${OC:-oc}


### PR DESCRIPTION
This pull request is to satisfy:

https://github.com/code-ready/crc/issues/977
https://github.com/code-ready/snc/issues/212

* Modified createdisk.sh to allow for overriding the cluster operating system.
* Added docs to README for building SNC for OKD 4
* In createdisk.sh, added a new variable; $BASE_OS which defaults to rhcos. Otherwise, it is can beset to fedora-coreos for disk image logic.
* Added logic for guestfish to be luks aware if OS is rhcos, otherwise it does not assume luks.

To build `snc` for `OKD` you will set the following ENV vars: (For example)

```bash
export OKD_VERSION=4.5.0-0.okd-2020-08-12-020541
export OPENSHIFT_PULL_SECRET_PATH="/tmp/pull_secret.json"
```

The pull secret is fake:

```bash
cat << EOF > /tmp/pull_secret.json
{"auths":{"fake":{"auth": "Zm9vOmJhcgo="}}}
EOF
```

In `createdisk.sh`, BASE_OS defaults to `rhcos`.   Otherwise, it is used to distinguish between `rhcos` and `fedora-coreos` for disk image logic.

