### PR TITLE
Add CVO override for cluster-node-tuning

### DIFF
--- a/cvo_override.yaml
+++ b/cvo_override.yaml
@@ -56,3 +56,8 @@
     name: kube-storage-version-migrator-operator
     namespace: openshift-kube-storage-version-migrator-operator
     unmanaged: true
+  - kind: Deployment
+    group: apps/v1
+    name: cluster-node-tuning-operator
+    namespace: openshift-cluster-node-tuning-operator
+    unmanaged: true

--- a/snc.sh
+++ b/snc.sh
@@ -433,6 +433,9 @@ ${OC} delete statefulset,deployment,daemonset --all -n openshift-cluster-storage
 # Clean-up 'openshift-kube-storage-version-migrator-operator' namespace
 ${OC} delete statefulset,deployment,daemonset --all -n openshift-kube-storage-version-migrator-operator
 
+# Clean-up 'openshift-cluster-node-tuning-operator' namespace
+${OC} delete statefulset,deployment,daemonset --all -n openshift-cluster-node-tuning-operator
+
 # Delete the v1beta1.metrics.k8s.io apiservice since we are already scale down cluster wide monitioring.
 # Since this CRD block namespace deletion forever.
 ${OC} delete apiservice v1beta1.metrics.k8s.io


### PR DESCRIPTION
Node tuning operator is used to tune the node as per workload and
it need tune profile to work and when it updated node needs reboot,
which is not possible for CRC so better to remove the resources
for tihs operator.