### PR TITLE
[POC] Performance tuning measures for single node OpenShift

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -390,6 +390,12 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rm -fr /etc/cni/net.d/200
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo journalctl --rotate'
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo journalctl --vacuum-time=1s'
 
+# Make all Kube-control plane manifest files as immutable. This helps not lose the performance related (ENV and initial resource requests) be overwritten by the respective oeprators
+${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo chattr +i  /etc/kubernetes/manifests/kube-apiserver-pod.yaml
+${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo chattr +i  /etc/kubernetes/manifests/kube-controller-manager-pod.yaml
+${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo chattr +i  /etc/kubernetes/manifests/kube-scheduler-pod.yaml
+${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo chattr +i  /etc/kubernetes/manifests/etcd-pod.yaml
+
 # Shutdown the VM
 sudo virsh shutdown ${VM_PREFIX}-master-0
 # Wait till instance shutdown gracefully

--- a/snc.sh
+++ b/snc.sh
@@ -445,3 +445,6 @@ ${OC} scale --replicas=1 ingresscontroller/default -n openshift-ingress-operator
 
 # Set default route for registry CRD from false to true.
 ${OC} patch config.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
+
+# Apply performance related changes to the CRC OpenShift components
+./tuning-crc-openshift-cluster/crc-perf-tuning.sh

--- a/tuning-crc-openshift-cluster/apply-kernel-parameters.sh
+++ b/tuning-crc-openshift-cluster/apply-kernel-parameters.sh
@@ -1,0 +1,5 @@
+SSH_KEYS_OF_MASTER_NODE=../id_rsa_crc
+set -x
+SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $SSH_KEYS_OF_MASTER_NODE"
+
+${SSH} core@master -- sudo grubby --update-kernel=ALL --args="transparent_hugepage=never "

--- a/tuning-crc-openshift-cluster/crc-perf-tuning.sh
+++ b/tuning-crc-openshift-cluster/crc-perf-tuning.sh
@@ -35,7 +35,7 @@ echo 'Create podpresets ....'
 ##  Source code for this Webhook is located at https://github.com/spaparaju/k8s-mutate-webhook
 #####
 echo 'Deploy MutatingWebhook for admission controller .....'
-oc apply -f admission-webhook.yaml
+oc apply -f https://raw.githubusercontent.com/spaparaju/k8s-mutate-webhook/master/deploy/webhook.yaml
 echo 'Wait for  MutatingWebhook to be available ....'
 sleep 120
 

--- a/tuning-crc-openshift-cluster/crc-perf-tuning.sh
+++ b/tuning-crc-openshift-cluster/crc-perf-tuning.sh
@@ -1,0 +1,79 @@
+OC=${OC:-oc}
+
+######
+##  Series of steps to inject necessary ENV variables and resources related changes for CRC ##
+#####
+
+
+######
+##  Enable v1alpha1/settings API for using Podpresets to set ENV variables while pods get created ##
+#####
+echo 'Enable Kube V1/alpha API .....'
+./enable-alpha-api.sh
+./make-kube-control-manifests-immutable.sh
+sleep 60
+
+######
+##  Update manifest files for the Kube. control plane (static pods created by Kubelet). ##
+##  Thes changes inject ENV variables and changes to the resources related to CRC OpenShift components ##
+#####
+echo 'Update Kube control plane manifest files ......'
+./make-kube-control-manifests-mutable.sh
+./update-kube-controlplane.sh
+./make-kube-control-manifests-immutable.sh
+echo 'Wait for Kube API to be available after the restart (triggered from updating the manifest files) .....'
+sleep 180
+
+######
+##  Now that v1alpha1/setting API is enabled, create podpresets across all the namespaces ##
+#####
+echo 'Create podpresets ....'
+./trigger-podpresets.sh
+
+######
+##  Deploy Mutatingwebhook for specifying the appropriate resources to CRC OpenShift pods ##
+##  Source code for this Webhook is located at https://github.com/spaparaju/k8s-mutate-webhook
+#####
+echo 'Deploy MutatingWebhook for admission controller .....'
+oc apply -f admission-webhook.yaml
+echo 'Wait for  MutatingWebhook to be available ....'
+sleep 120
+
+######
+##  Now that Podpresets (across all the openshift- namespaces) Mutatingwebhook(cluster wide) are available, delete CRC OpenShift pods to get them recreated (by the respective operators) with the required ENV variables (from Podpresets) and required resources specified (from MutatingWebhook) ##
+#####
+echo 'Delete pods to inject ENV. and memroy/cpu initial requests ....'
+./delete-pods.sh
+echo 'Wait for pods to get recreated by the respective operators ....'
+sleep 60
+
+######
+##  Remove all the resources related MutatingWebhook (MutatingWebhook, service and the deployment for the webhook) ##
+#####
+echo 'Removing admission webhooks ..'
+./remove-admission-webhook.sh
+sleep 60
+
+######
+##  Delete all the created podpresets
+#####
+echo 'Removing podpresets across all the namespaces ..'
+./remove-podpresets.sh
+sleep 60
+
+######
+##  From Kube-API server, removing support for v1alpha1/serttings API and pre-compiled webhooks 
+#####
+echo 'Removing support for v1alpha1/serttings APi and pre-compiled webhooks...'
+./make-kube-control-manifests-mutable.sh
+./remove-alpha-api.sh
+./make-kube-control-manifests-immutable.sh
+sleep 120
+
+######
+##  Apply required RHCOS Kernel parameters
+#####
+echo 'Apply required Kernel paramters to the CRC VM..'
+./apply-kernel-parameters.sh
+
+echo 'All the perfomance settings been applied. DONE'

--- a/tuning-crc-openshift-cluster/delete-pods.sh
+++ b/tuning-crc-openshift-cluster/delete-pods.sh
@@ -1,0 +1,33 @@
+OC=${OC:-oc}
+
+delete_pods_for_a_namespace() {
+	${OC} delete pods -n  $1 --all
+	sleep 30
+}
+
+delete_pods_for_a_namespace openshift-authentication  
+delete_pods_for_a_namespace openshift-authentication-operator 
+delete_pods_for_a_namespace openshift-cluster-machine-approver 
+delete_pods_for_a_namespace openshift-cluster-node-tuning-operator 
+delete_pods_for_a_namespace openshift-cluster-samples-operator 
+delete_pods_for_a_namespace openshift-config-operator  
+delete_pods_for_a_namespace openshift-console 
+delete_pods_for_a_namespace openshift-console-operator  
+delete_pods_for_a_namespace openshift-controller-manager  
+delete_pods_for_a_namespace openshift-controller-manager-operator  
+delete_pods_for_a_namespace openshift-dns
+delete_pods_for_a_namespace openshift-dns-operator  
+delete_pods_for_a_namespace openshift-image-registry   
+delete_pods_for_a_namespace openshift-kube-storage-version-migrator 
+delete_pods_for_a_namespace openshift-marketplace  
+delete_pods_for_a_namespace openshift-multus  
+delete_pods_for_a_namespace openshift-network-operator   
+delete_pods_for_a_namespace openshift-operator-lifecycle-manager   
+delete_pods_for_a_namespace openshift-sdn   
+delete_pods_for_a_namespace openshift-service-ca   
+delete_pods_for_a_namespace openshift-service-ca-operator    
+delete_pods_for_a_namespace openshift-apiserver  
+delete_pods_for_a_namespace openshift-apiserver-operator 
+delete_pods_for_a_namespace openshift-ingress 
+delete_pods_for_a_namespace openshift-ingress-operator 
+sleep 160

--- a/tuning-crc-openshift-cluster/enable-alpha-api.sh
+++ b/tuning-crc-openshift-cluster/enable-alpha-api.sh
@@ -1,0 +1,18 @@
+SSH_KEYS_OF_MASTER_NODE=../id_rsa_crc
+JQ=${JQ:-jq}
+
+set -x
+SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $SSH_KEYS_OF_MASTER_NODE"
+SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $SSH_KEYS_OF_MASTER_NODE"
+
+${SSH} core@master -- sudo cat /etc/kubernetes/manifests/kube-apiserver-pod.yaml  > current_kubeapiserver_manifest.json
+current_args=`cat current_kubeapiserver_manifest.json | jq -r '.spec.containers[]  | select(.name == "kube-apiserver") | .args[0]'`
+additional_args=' --runtime-config=settings.k8s.io/v1alpha1=true --enable-admission-plugins=NamespaceAutoProvision,MutatingAdmissionWebhook,PodPreset '
+new_args="${current_args} ${additional_args}"
+echo $new_args
+${JQ}  --arg new_args "$new_args" '(.spec.containers[] | select(.name == "kube-apiserver") | .args[0]) |= $new_args' current_kubeapiserver_manifest.json > updated_kubeapiserver_manifest.json
+cat updated_kubeapiserver_manifest.json | jq -c  > unformatted_updated_kubeapiserver_manifest.json
+${SCP} -r unformatted_updated_kubeapiserver_manifest.json  core@master:/home/core/enable-alphaapi-kube-apiserver-pod.yaml
+${SSH} core@master -- sudo cp /home/core/enable-alphaapi-kube-apiserver-pod.yaml /etc/kubernetes/manifests/kube-apiserver-pod.yaml
+## cleanup temp. files created ##
+rm current_kubeapiserver_manifest.json updated_kubeapiserver_manifest.json unformatted_updated_kubeapiserver_manifest.json

--- a/tuning-crc-openshift-cluster/make-kube-control-manifests-immutable.sh
+++ b/tuning-crc-openshift-cluster/make-kube-control-manifests-immutable.sh
@@ -1,0 +1,8 @@
+SSH_KEYS_OF_MASTER_NODE=../id_rsa_crc
+
+SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $SSH_KEYS_OF_MASTER_NODE"
+
+${SSH} core@master -- sudo chattr +i  /etc/kubernetes/manifests/kube-apiserver-pod.yaml 
+${SSH} core@master -- sudo chattr +i  /etc/kubernetes/manifests/kube-controller-manager-pod.yaml
+${SSH} core@master -- sudo chattr +i  /etc/kubernetes/manifests/kube-scheduler-pod.yaml
+${SSH} core@master -- sudo chattr +i  /etc/kubernetes/manifests/etcd-pod.yaml

--- a/tuning-crc-openshift-cluster/make-kube-control-manifests-mutable.sh
+++ b/tuning-crc-openshift-cluster/make-kube-control-manifests-mutable.sh
@@ -1,0 +1,8 @@
+SSH_KEYS_OF_MASTER_NODE=../id_rsa_crc
+
+SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $SSH_KEYS_OF_MASTER_NODE"
+
+${SSH} core@master -- sudo chattr -i  /etc/kubernetes/manifests/kube-apiserver-pod.yaml
+${SSH} core@master -- sudo chattr -i  /etc/kubernetes/manifests/kube-controller-manager-pod.yaml
+${SSH} core@master -- sudo chattr -i  /etc/kubernetes/manifests/kube-scheduler-pod.yaml
+${SSH} core@master -- sudo chattr -i  /etc/kubernetes/manifests/etcd-pod.yaml

--- a/tuning-crc-openshift-cluster/podpreset-template.yaml
+++ b/tuning-crc-openshift-cluster/podpreset-template.yaml
@@ -1,0 +1,14 @@
+apiVersion: settings.k8s.io/v1alpha1
+kind: PodPreset
+metadata:
+  name: crc-performance-turning
+  namespace: NAMESPACE_TO_REPLACE
+spec:
+  selector:
+   matchExpressions:
+    - {key: environment, operator: NotIn, values: [dev]}
+  env:
+    - name: "GODEBUG"
+      value: "madvdontneed=1"
+    - name: "GOGC"
+      value: "5"

--- a/tuning-crc-openshift-cluster/remove-admission-webhook.sh
+++ b/tuning-crc-openshift-cluster/remove-admission-webhook.sh
@@ -1,0 +1,6 @@
+## These admission webhook components (deployed with admission-webhook.yaml) enable updates to resource requests/limits to the Pod specs. 
+## The source-code for this admission controller is located at 'https://github.com/spaparaju/k8s-mutate-webhook'. 
+## Once all the OpenShift pods update their pod spec with the required resource requests/limits, these webhook related components are removed  so that the created CRC disk-image  does not contain any NON-standard OpenShift components.
+
+OC=${OC:-oc}
+${OC} delete MutatingWebhookConfiguration/mutateme svc/mutateme deploy/mutateme

--- a/tuning-crc-openshift-cluster/remove-alpha-api.sh
+++ b/tuning-crc-openshift-cluster/remove-alpha-api.sh
@@ -1,0 +1,16 @@
+SSH_KEYS_OF_MASTER_NODE=../id_rsa_crc
+JQ=${JQ:-jq}
+
+SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $SSH_KEYS_OF_MASTER_NODE"
+SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $SSH_KEYS_OF_MASTER_NODE"
+
+${SSH} core@master -- sudo cat /etc/kubernetes/manifests/kube-apiserver-pod.yaml  > current_kubeapiserver_manifest.json
+current_args=`cat current_kubeapiserver_manifest.json | jq -r '.spec.containers[]  | select(.name == "kube-apiserver") | .args[0]'`
+new_args=`echo "${current_args/'--runtime-config=settings.k8s.io/v1alpha1=true'/''}"`
+yes_args=`echo "${new_args/'--enable-admission-plugins=NamespaceAutoProvision,MutatingAdmissionWebhook,PodPreset'/''}"`
+${JQ}  --arg yes_args "$yes_args" '(.spec.containers[] | select(.name == "kube-apiserver") | .args[0]) |= $yes_args' current_kubeapiserver_manifest.json > updated_kubeapiserver_manifest.json
+cat updated_kubeapiserver_manifest.json | jq -c  > unformatted_updated_kubeapiserver_manifest.json
+${SCP} -r unformatted_updated_kubeapiserver_manifest.json  core@master:/home/core/enable-alphaapi-kube-apiserver-pod.yaml
+${SSH} core@master -- sudo cp /home/core/enable-alphaapi-kube-apiserver-pod.yaml /etc/kubernetes/manifests/kube-apiserver-pod.yaml
+# cleanup temp. files created ##
+rm current_kubeapiserver_manifest.json updated_kubeapiserver_manifest.json unformatted_updated_kubeapiserver_manifest.json

--- a/tuning-crc-openshift-cluster/remove-podpresets.sh
+++ b/tuning-crc-openshift-cluster/remove-podpresets.sh
@@ -1,0 +1,10 @@
+OC=${OC:-oc}
+
+for i in {1..60}
+do
+	namespace=`oc get ns |  awk 'NR=="'"$i"'"{print $1}'`
+	if [[ "$namespace" =~ "openshift-" ]]; then
+			echo 'Removing podpreset for the namespace: "'"$namespace"'"' 
+			${OC} delete podpreset/crc-performance-turning -n $namespace
+	fi
+done

--- a/tuning-crc-openshift-cluster/trigger-podpreset.yaml
+++ b/tuning-crc-openshift-cluster/trigger-podpreset.yaml
@@ -1,0 +1,14 @@
+apiVersion: settings.k8s.io/v1alpha1
+kind: PodPreset
+metadata:
+  name: crc-performance-turning
+  namespace: "openshift-vsphere-infra"
+spec:
+  selector:
+   matchExpressions:
+    - {key: environment, operator: NotIn, values: [dev]}
+  env:
+    - name: "GODEBUG"
+      value: "madvdontneed=1"
+    - name: "GOGC"
+      value: "5"

--- a/tuning-crc-openshift-cluster/trigger-podpresets.sh
+++ b/tuning-crc-openshift-cluster/trigger-podpresets.sh
@@ -1,0 +1,11 @@
+OC=${OC:-oc}
+
+for i in {1..60}
+do
+	namespace=`oc get ns |  awk 'NR=="'"$i"'"{print $1}'`
+	if [[ "$namespace" =~ "openshift-" ]]; then
+			sed 's/NAMESPACE_TO_REPLACE/"'"$namespace"'"/g' podpreset-template.yaml > trigger-podpreset.yaml
+			echo 'creating podpreset for the namespace: "'"$namespace"'"' 
+			${OC} apply -f trigger-podpreset.yaml
+	fi
+done

--- a/tuning-crc-openshift-cluster/update-kube-controlplane.sh
+++ b/tuning-crc-openshift-cluster/update-kube-controlplane.sh
@@ -1,0 +1,109 @@
+SSH_KEYS_OF_MASTER_NODE=../id_rsa_crc
+SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $SSH_KEYS_OF_MASTER_NODE"
+SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $SSH_KEYS_OF_MASTER_NODE"
+
+JQ=${JQ:-jq}
+YQ=${YQ:-yq}
+
+ update_kube_apiserver_manifests() {
+    ${SSH} core@master -- sudo cat $1  > current_manifest.json
+    new_memory_value=$2
+    new_cpu_value=$3
+    ${JQ}  --arg new_memory_value "$new_memory_value" '(.spec.containers[].resources.requests.memory) |= $new_memory_value' current_manifest.json > updated_wth_memory_manifest.json
+    ${JQ}  --arg new_cpu_value "$new_cpu_value" '(.spec.containers[].resources.requests.cpu) |= $new_cpu_value' updated_wth_memory_manifest.json > updated_wth_cpu_manifest.json
+    ${JQ} '.spec.containers[].env |= . + [{"name": "GOGC", "value": "5"}, {"name": "GODEBUG", "value": "madvdontneed=1"}] ' updated_wth_cpu_manifest.json > updated_with_env_manifest.json
+    new_kubeapi_cpu_value=$4
+    ${JQ}  --arg new_kubeapi_cpu_value "$new_kubeapi_cpu_value" '(.spec.containers[] | select(.name == "kube-apiserver") | .resources.requests.cpu) |= $new_kubeapi_cpu_value' updated_with_env_manifest.json > updated_with_cpu_requests_manifest.json 
+    kubeapi_limit_cpu_value=$5
+    ${JQ}  --arg kubeapi_limit_cpu_value "$kubeapi_limit_cpu_value" '(.spec.containers[] | select(.name == "kube-apiserver") | .resources.limits.cpu) |= $kubeapi_limit_cpu_value' updated_with_cpu_requests_manifest.json  > final_manifest.json
+    cat final_manifest.json | ${JQ} -c > unformatted_final_manifest.json
+
+    ${SCP} -r unformatted_final_manifest.json core@master:/home/core/updated-kube-apiserver-manifest.yaml
+    ${SSH} core@master -- sudo cp /home/core/updated-kube-apiserver-manifest.yaml $1
+    ## Remove temp. files created
+    rm current_manifest.json updated_wth_memory_manifest.json updated_wth_cpu_manifest.json updated_with_env_manifest.json updated_with_cpu_requests_manifest.json final_manifest.json unformatted_final_manifest.json
+}
+
+ update_kube_controller_manifests() {
+    ${SSH} core@master -- sudo cat $1  > current_manifest.json
+    new_memory_value=$2
+    new_cpu_value=$3
+    ${JQ}  --arg new_memory_value "$new_memory_value" '(.spec.containers[].resources.requests.memory) |= $new_memory_value' current_manifest.json > updated_wth_memory_manifest.json
+    ${JQ}  --arg new_cpu_value "$new_cpu_value" '(.spec.containers[].resources.requests.cpu) |= $new_cpu_value' updated_wth_memory_manifest.json > updated_wth_cpu_manifest.json
+    ${JQ} '.spec.containers[].env |= . + [{"name": "GOGC", "value": "5"}, {"name": "GODEBUG", "value": "madvdontneed=1"}] ' updated_wth_cpu_manifest.json > updated_with_env_manifest.json
+    new_kube_controller_cpu_value=$4
+    ${JQ}  --arg new_kube_controller_cpu_value "$new_kube_controller_cpu_value" '(.spec.containers[] | select(.name == "kube-controller-manager") | .resources.requests.cpu) |= $new_kube_controller_cpu_value' updated_with_env_manifest.json  > updated_with_cpu_requests_manifest.json
+    kube_controller_limit_cpu_value=$5
+    ${JQ}  --arg kube_controller_limit_cpu_value "$kube_controller_limit_cpu_value" '(.spec.containers[] | select(.name == "kube-controller-manager") | .resources.limits.cpu) |= $kube_controller_limit_cpu_value' updated_with_cpu_requests_manifest.json  > final_manifest.json
+    cat final_manifest.json | ${JQ} -c > unformatted_final_manifest.json
+
+    ${SCP} -r unformatted_final_manifest.json core@master:/home/core/updated-kube-control-manager-manifest.yaml
+    ${SSH} core@master -- sudo cp /home/core/updated-kube-control-manager-manifest.yaml $1
+    ## Remove temp. files created
+    rm current_manifest.json updated_wth_memory_manifest.json updated_wth_cpu_manifest.json updated_with_env_manifest.json updated_with_cpu_requests_manifest.json final_manifest.json unformatted_final_manifest.json
+}
+
+ update_kube_scheduler_manifests() {
+    ${SSH} core@master -- sudo cat $1  > current_manifest.json
+    new_memory_value=$2
+    new_cpu_value=$3
+    ${JQ}  --arg new_memory_value "$new_memory_value" '(.spec.containers[].resources.requests.memory) |= $new_memory_value' current_manifest.json > updated_wth_memory_manifest.json
+    ${JQ}  --arg new_cpu_value "$new_cpu_value" '(.spec.containers[].resources.requests.cpu) |= $new_cpu_value' updated_wth_memory_manifest.json > updated_wth_cpu_manifest.json
+    ${JQ} '.spec.containers[].env |= . + [{"name": "GOGC", "value": "5"}, {"name": "GODEBUG", "value": "madvdontneed=1"}] ' updated_wth_cpu_manifest.json  > final_manifest.json
+    cat final_manifest.json | ${JQ} -c > unformatted_final_manifest.json
+
+    ${SCP} -r unformatted_final_manifest.json core@master:/home/core/updated-kube-scheduler-manifest.yaml
+    ${SSH} core@master -- sudo cp /home/core/updated-kube-scheduler-manifest.yaml $1
+    ## Remove temp. files created
+    rm current_manifest.json updated_wth_memory_manifest.json updated_wth_cpu_manifest.json  final_manifest.json unformatted_final_manifest.json
+}
+
+ update_etcd_manifests() {
+    ${SSH} core@master -- sudo cat $1  > current_manifest.yaml
+    new_memory_value=$2
+    new_cpu_value=$3
+    ${YQ} r -j current_manifest.yaml | ${JQ}  --arg new_memory_value "$new_memory_value" '(.spec.containers[].resources.requests.memory) |= $new_memory_value' -  | ${YQ} r -P - > updated_memory_manifest.yaml
+    ${YQ} r -j updated_memory_manifest.yaml | ${JQ}  --arg new_cpu_value "$new_cpu_value" '(.spec.containers[].resources.requests.cpu) |= $new_cpu_value' -  | ${YQ} r -P - > updated_cpu_manifest.yaml
+    ${YQ} r -j updated_cpu_manifest.yaml | ${JQ}  --arg new_memory_value "$new_memory_value" '(.spec.initContainers[].resources.requests.memory) |= $new_memory_value' -  | ${YQ} r -P - > updated_init_containers_memory_manifest.yaml
+    ${YQ} r -j updated_init_containers_memory_manifest.yaml | ${JQ}  --arg new_cpu_value "$new_cpu_value" '(.spec.initContainers[].resources.requests.cpu) |= $new_cpu_value' -  | ${YQ} r -P - > updated_init_containers_cpu_manifest.yaml
+    ${YQ} r -j updated_init_containers_cpu_manifest.yaml | ${JQ} '.spec.containers[].env |= . + [{"name": "GOGC", "value": "5"}, {"name": "GODEBUG", "value": "madvdontneed=1"}] ' -  | ${YQ} r -P - > updated_with_env_manifest.yaml
+    ${YQ} r -j updated_with_env_manifest.yaml | ${JQ} '.spec.initContainers[].env |= . + [{"name": "GOGC", "value": "5"}, {"name": "GODEBUG", "value": "madvdontneed=1"}] ' -  | ${YQ} r -P - > updated_init_containers_with_env_manifest.yaml
+    new_etcd_cpu_value=$4
+    ${YQ} r -j updated_init_containers_with_env_manifest.yaml | ${JQ}  --arg new_etcd_cpu_value "$new_etcd_cpu_value" '(.spec.containers[] | select(.name == "etcd") | .resources.requests.cpu) |= $new_etcd_cpu_value' -  > updated_with_new_cpu_request_manifest.yaml
+    etcd_cpu_limit_value=$4
+    ${YQ} r -j updated_with_new_cpu_request_manifest.yaml | ${JQ}  --arg etcd_cpu_limit_value "$etcd_cpu_limit_value" '(.spec.containers[] | select(.name == "etcd") | .resources.limits.cpu) |= $etcd_cpu_limit_value' -  > updated_final_manifest.yaml
+
+    ${SCP} -r updated_final_manifest.yaml core@master:/home/core/updated-etcd-final-manifest.yaml
+    ${SSH} core@master -- sudo cp /home/core/updated-etcd-final-manifest.yaml $1
+    ## Remove temp. files created
+    rm  current_manifest.yaml updated_memory_manifest.yaml updated_cpu_manifest.yaml updated_init_containers_memory_manifest.yaml updated_with_env_manifest.yaml updated_init_containers_with_env_manifest.yaml updated_init_containers_cpu_manifest.yaml updated_with_new_cpu_request_manifest.yaml updated_final_manifest.yaml
+}
+
+update_kubelet_systemd_service() {
+    ${SSH} core@master -- sudo cat $1  > current_kubelet.conf
+    ${YQ} w  current_kubelet.conf systemReserved.cpu $3  > updated_cpu_kubelet.conf
+    ${YQ} w  updated_cpu_kubelet.conf systemReserved.memory $2  > updated_memory_kubelet.conf
+    ${YQ} w  updated_memory_kubelet.conf containerLogMaxSize $4  > updated_final_kubelet.conf
+
+    ${SCP} -r updated_final_kubelet.conf core@master:/home/core/updated-kubelet.conf
+    ${SSH} core@master -- sudo cp /home/core/updated-kubelet.conf $1
+    ## clean up temp. files created
+    rm current_kubelet.conf updated_cpu_kubelet.conf updated_memory_kubelet.conf updated_final_kubelet.conf
+}
+
+
+echo '------------- Applying changes to Kubelet -----------'
+update_kubelet_systemd_service /etc/kubernetes/kubelet.conf 150Mi 200m 2Mi
+
+echo '------------- Applying changes to Kube API server  -----------'
+update_kube_apiserver_manifests   /etc/kubernetes/manifests/kube-apiserver-pod.yaml 10Mi 10m 500m 700m
+
+echo '------------- Applying changes to Kube Scheduler  -----------'
+update_kube_scheduler_manifests  /etc/kubernetes/manifests/kube-scheduler-pod.yaml 10Mi 15m
+
+echo '------------- Applying changes to Kube Control manager  -----------'
+update_kube_controller_manifests /etc/kubernetes/manifests/kube-controller-manager-pod.yaml 10Mi 10m 300m 400m
+
+echo '------------- Applying changes to Etcd -----------'
+update_etcd_manifests   /etc/kubernetes/manifests/etcd-pod.yaml 10Mi 10m 300m 500m
+


### PR DESCRIPTION
**Goals**

1. Figure out the reasons behind huge resource requirements for CRC OpenShift components
2. Enable users with around 4 GB and 4 VCPUs can start using CRC on their personal laptops. This enables majority of the developer community (with 8 GB laptops) to start using single node OpenShift cluster

**Approach**
Without changing the core payload of OCP used for a single node, these performance tuning changes were enabled (while creating the single node OpenShift disk image). Here is the mechanism to enable these performance tuning changes. The disk image for single node OpenShift ‘does not contain’ any the additional components (v1/alpha api, Pod presets, admission controllers) to enable performance tuning changes while creating the disk image.

**Single node OpenShift bundles created with these changes:**

- [Libvirt bundle](https://drive.google.com/file/d/1FVZFSsQrZpWzZ7tRdSf_v48CVbT7PYRo/view?usp=sharing)
- [Hyperkit bundle](https://drive.google.com/file/d/1SPtaHQRfEiqQMmJ6FvAvNvAgxw89mtFW/view?usp=sharing)

**[WHICH]Performance tuning options tried out to reduce footprint of single node OpenShift**

**1) At Kernel level:**
Disable huge memory pages: RHCOS defaults to ‘huge memory pages’. Disabling ‘huge memory pages’ and switching to typical 4K pages helps GoLang to gather more idle memory (more and smaller pages can be ready for garbage collection). Rebooting node with Linux kernel parameter ‘transparent_hugepage=never’ enables the switch to smaller memory pages (4K).

**2) At GoLang level:**
Enable GoLang applications to speed up returning idle memory back to the Operating system (thru GoLang specific env. variables) :

- Set and configure "GOGC" (a new collection is triggered before newly allocated data in comparison to the current live data reaches this %)
- "GODEBUG=madvdontneed=1 for faster releases to RSS of OS

**3) Update resource requests/limits:**

- For Kube control plane components launched as static pods
- For pods across all the openshift namespaces

**4) Kubelet level changes:**

- Reduce ‘system-reserved’ resources (i.e. increase ‘allocatable’ resources)
- Reduce max. Container log size

**[HOW] Performance tuning options are applied**
(_crc-perf-tuning.sh_ is the entry point for all these below indicated changes)

**1) At Kernel level:**
With grubby update to include kernel parameter to disable ‘huge pages’. (_apply-kernel-parameters.sh_)

**2) At GoLang level:**
(a) GOGC, GODEBUG environment variables are injected into the pod spec of pods (across all the openshift namespaces) through ‘Pod Presets’, a pre-compiled admission controller. ‘Pod presets’ require enabling support for ‘v1/alpha1(settings)’ at Kube API level. (_enable-alpha-api.sh_, _trigger-podpresets.sh_)
(b) GOGC, GODEBUG environment variables are included in the manifest files of Kube control plane components (launched as static pods by Kubelet) (_update-kube-controlplane.sh_)

**3) Update resource requests/limits:**
(a) Enabling pre-compiled admission controller ‘MutatingAdmissionWebhook’ to inject required resource requests/limits values for pods across all the openshift namespaces (_https://raw.githubusercontent.com/spaparaju/k8s-mutate-webhook/master/deploy/webhook.yaml_)
(b) Resources requests/limits are updated in the manifest files of Kube control plane components (launched as static pods by Kubelet) (_update-kube-controlplane.sh_)

**4) Kubelet level changes:**
Reduce ‘system-reserved’ resources by updating configuration file of kubelet (_update-kube-controlplane.sh_)

