### PR TITLE
Add openshift client oc in the bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ openshift-install
 pull-secret
 oc
 yq
+openshift-clients/

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -164,6 +164,9 @@ function copy_additional_files {
     cp id_rsa_crc $destDir/
     chmod 400 $destDir/id_rsa_crc
 
+    # Copy oc client
+    cp openshift-clients/linux/oc $destDir/
+
     update_json_description $srcDir $destDir
 }
 
@@ -178,6 +181,9 @@ function generate_hyperkit_directory {
     cp $srcDir/${CRC_VM_NAME}.qcow2 $destDir/
     cp $tmpDir/vmlinuz-${kernel_release} $destDir/
     cp $tmpDir/initramfs-${kernel_release}.img $destDir/
+
+    # Copy oc client
+    cp openshift-clients/mac/oc $destDir/
 
     # Update the bundle metadata info
     cat $srcDir/crc-bundle-info.json \
@@ -195,6 +201,9 @@ function generate_hyperv_directory {
     cp $srcDir/kubeadmin-password $destDir/
     cp $srcDir/kubeconfig $destDir/
     cp $srcDir/id_rsa_crc $destDir/
+
+    # Copy oc client
+    cp openshift-clients/windows/oc.exe $destDir/
 
     ${QEMU_IMG} convert -f qcow2 -O vhdx -o subformat=dynamic $srcDir/${CRC_VM_NAME}.qcow2 $destDir/${CRC_VM_NAME}.vhdx
 

--- a/snc.sh
+++ b/snc.sh
@@ -256,12 +256,16 @@ function delete_operator() {
         ${OC} wait --for=delete pod/${pod} --timeout=120s -n ${namespace} || ${OC} delete pod/${pod} --grace-period=0 --force -n ${namespace} || true
 }
 
+# Download the oc binary for all platforms
+mkdir -p openshift-clients/linux openshift-clients/mac openshift-clients/windows
+curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/linux oc
+curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-mac-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/mac oc
+curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-windows-${OPENSHIFT_RELEASE_VERSION}.zip" > openshift-clients/windows/oc.zip
+unzip -o -d openshift-clients/windows/ openshift-clients/windows/oc.zip
+
 # Download the oc binary if not present in current directory
 if ! which ${OC}; then
-    if [[ ! -e oc ]] ; then
-        curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar zx oc
-    fi
-    OC=./oc
+    OC=./openshift-clients/linux/oc
 fi
 
 # Download yq for manipulating in place yaml configs


### PR DESCRIPTION
This decorrelates a little bit more a CodeReady Container version
from an openshift version. `crc` will now have to pick the oc client in
the bundle instead of downloading and adding it in his static
resources.

Relates to https://github.com/code-ready/crc/pull/1511 - it will simplify it.