### PR TITLE
Make crc-bundle-info.json the first element in the tar archive

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -412,7 +412,7 @@ create_qemu_image $libvirtDestDir
 
 copy_additional_files $1 $libvirtDestDir
 
-tar cSf - $libvirtDestDir | xz --threads=0 >$libvirtDestDir.$crcBundleSuffix
+tar cSf - --sort=name $libvirtDestDir | xz --threads=0 >$libvirtDestDir.$crcBundleSuffix
 
 # HyperKit image generation
 # This must be done after the generation of libvirt image as it reuse some of
@@ -421,7 +421,7 @@ hyperkitDestDir="crc_hyperkit_${destDirSuffix}"
 mkdir $hyperkitDestDir
 generate_hyperkit_directory $libvirtDestDir $hyperkitDestDir $1
 
-tar cSf - $hyperkitDestDir | xz --threads=0 >$hyperkitDestDir.$crcBundleSuffix
+tar cSf - --sort=name $hyperkitDestDir | xz --threads=0 >$hyperkitDestDir.$crcBundleSuffix
 
 # HyperV image generation
 #
@@ -431,7 +431,7 @@ hypervDestDir="crc_hyperv_${destDirSuffix}"
 mkdir $hypervDestDir
 generate_hyperv_directory $libvirtDestDir $hypervDestDir
 
-tar cSf - $hypervDestDir | xz --threads=0 >$hypervDestDir.$crcBundleSuffix
+tar cSf - --sort=name $hypervDestDir | xz --threads=0 >$hypervDestDir.$crcBundleSuffix
 
 # Cleanup up packages and vmlinux/initramfs files
 rm -fr $1/packages $1/vmlinuz* $1/initramfs*


### PR DESCRIPTION
Using --sort=name moves crc-bundle-info.json to the first place in the
crcbundle archive. It allows crc and other programs to read the first
bytes of the archive to get the json metadata.
Programs need to read the first ~3KB of the bundle to get the json.