### PR TITLE
RFC: Optionally add a default pull secret in the bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,12 @@ export OPENSHIFT_PULL_SECRET_PATH="/tmp/pull_secret.json"
 ./snc.sh
 ```
 
-- When the build is complete, create the disk image as described above.
+- When the build is complete, create the disk image as described below.
+
+```
+export BUNDLED_PULL_SECRET_PATH="/tmp/pull_secret.json"
+./createdisk.sh crc-tmp-install-data
+```
 
 ## Troubleshooting
 

--- a/crc-bundle-info.json.sample
+++ b/crc-bundle-info.json.sample
@@ -32,6 +32,8 @@
     # Name of the file containing the kubeadmin password for use in the
     # openshift console
     "kubeadminPasswordFile": "kubeadmin-password"
+    # pull secret that can be used to fetch OpenShift container images (optional)
+    # "openshiftPullSecret": "default-pull-secret"
   },
   "nodes": [
     {

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -149,6 +149,19 @@ function update_json_description {
         >$destDir/crc-bundle-info.json
 }
 
+function eventually_add_pull_secret {
+    local destDir=$1
+
+    if [[ -f "$BUNDLED_PULL_SECRET_PATH" ]]
+    then
+      cat "$BUNDLED_PULL_SECRET_PATH" > "$destDir/default-pull-secret"
+      cat $destDir/crc-bundle-info.json \
+          | ${JQ} '.clusterInfo.openshiftPullSecret = "default-pull-secret"' \
+          >$destDir/crc-bundle-info.json.tmp
+      mv $destDir/crc-bundle-info.json.tmp $destDir/crc-bundle-info.json
+    fi
+}
+
 function copy_additional_files {
     local srcDir=$1
     local destDir=$2
@@ -168,6 +181,8 @@ function copy_additional_files {
     cp openshift-clients/linux/oc $destDir/
 
     update_json_description $srcDir $destDir
+
+    eventually_add_pull_secret $destDir
 }
 
 function generate_hyperkit_directory {


### PR DESCRIPTION
This pull secret can be used to configure the cluster later on. It would
be primarily used by OKD to distribute a good default pull secret.

It can be also used by a large company, where developers are not allowed
to register on cloud.redhat.com to get a pull secret, to internally
distribute the bundle with a pre-defined pull secret. 

cc @cgruver 

Related to https://github.com/code-ready/snc/issues/237