### PR TITLE
Wait till the ssh connection is available

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -363,8 +363,8 @@ until sudo virsh domstate ${VM_PREFIX}-master-0 | grep shut; do
 done
 
 sudo virsh start ${VM_PREFIX}-master-0
-# Wait till it is started properly.
-until ping -c1 api.${CRC_VM_NAME}.${BASE_DOMAIN} >/dev/null 2>&1; do
+# Wait till ssh connection available
+until ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- "exit 0" >/dev/null 2>&1; do
     echo " ${VM_PREFIX}-master-0 still booting"
     sleep 2
 done


### PR DESCRIPTION
Only ping doesn't provide enough info if the sshd service is running
on the VM so it might fails and all the variable which are depend on
it have empty string.

```
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_crc core@api.crc.testing -- 'cat /proc/cmdline | grep -oP "(?<=rhcos-).*(?=/vmlinuz)"'
ssh: connect to host api.crc.testing port 22: Connection refused
+ ostree_hash=
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_crc core@api.crc.testing -- 'uname -r'
ssh: connect to host api.crc.testing port 22: Connection refused
+ kernel_release=
++ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_crc core@api.crc.testing -- 'cat /proc/cmdline'
ssh: connect to host api.crc.testing port 22: Connection refused
+ kernel_cmd_line=
+ scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_crc 'core@api.crc.testing:/boot/ostree/rhcos-/*' crc-tmp-install-data
ssh: connect to host api.crc.testing port 22: Connection refused
+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_crc core@api.crc.testing -- 'sudo nmcli conn add type dummy ifname eth10 con-name internalEtcd ip4 192.168.126.11/24  && sudo nmcli conn up internalEtcd'
ssh: connect to host api.crc.testing port 22: Connection refused
+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_crc core@api.crc.testing -- 'sudo sed -i.back '\''/kubelet /a\      --node-ip=192.168.126.11 \\'\'' /etc/systemd/system/kubelet.service'
ssh: connect to host api.crc.testing port 22: Connection refused
+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_crc core@api.crc.testing -- 'sudo rm -fr /etc/cni/net.d/100-crio-bridge.conf'
ssh: connect to host api.crc.testing port 22: Connection refused
+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_crc core@api.crc.testing -- 'sudo rm -fr /etc/cni/net.d/200-loopback.conf'
ssh: connect to host api.crc.testing port 22: Connection refused
+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_crc core@api.crc.testing -- 'sudo journalctl --rotate'
ssh: connect to host api.crc.testing port 22: Connection refused
+ ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_crc core@api.crc.testing -- 'sudo journalctl --vacuum-time=1s'
ssh: connect to host api.crc.testing port 22: Connection refused
+ sudo virsh shutdown crc-q5hwh-master-0
```