### PR TITLE
Remove version info from oc binary download

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -273,9 +273,9 @@ fi
 
 # Download the oc binary for all platforms
 mkdir -p openshift-clients/linux openshift-clients/mac openshift-clients/windows
-curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/linux oc
-curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-mac-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/mac oc
-curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-windows-${OPENSHIFT_RELEASE_VERSION}.zip" > openshift-clients/windows/oc.zip
+curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux.tar.gz" | tar -zx -C openshift-clients/linux oc
+curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-mac.tar.gz" | tar -zx -C openshift-clients/mac oc
+curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-windows.zip" > openshift-clients/windows/oc.zip
 ${UNZIP} -o -d openshift-clients/windows/ openshift-clients/windows/oc.zip
 
 # Download the oc binary if not present in current directory


### PR DESCRIPTION
On mirror there is always client link which doesn't need version
info which is helpful for scripting part. Right now if we use the
version info then have a `OPENSHIFT_VERSION=candidate` will not
able to download the client binaries since the uri is not correct.

```
curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/candidate/openshift-client-linux-candidate.tar.gz
+ tar -zx -C openshift-clients/linux oc
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   371  100   371    0     0   2768      0 --:--:-- --:--:-- --:--:--  2768
gzip: stdin: not in gzip format
```