### PR TITLE
Add script used by the CI to wait the cluster to be stable

### DIFF
--- a/wait-for-cluster.sh
+++ b/wait-for-cluster.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# wait till the cluster is stable
+sleep 5m
+export KUBECONFIG=crc-tmp-install-data/auth/kubeconfig
+# Remove all the failed Pods
+oc delete pods --field-selector=status.phase=Failed -A
+# Wait till all the pods are either running or pending or completed or in terminating state
+while oc get pod --no-headers --all-namespaces | grep -v Running | grep -v Completed | grep -v Terminating | grep -v Pending; do
+   sleep 2
+done
+# Check the cluster operator output, status for available should be true for all operators
+while oc get co -ojsonpath='{.items[*].status.conditions[?(@.type=="Available")].status}' | grep -v True; do
+   sleep 2
+done


### PR DESCRIPTION
Extracted from https://github.com/openshift/release/blob/431aac76304a21b1c290811441d8b12b9252450c/ci-operator/step-registry/openshift/e2e/gcp/crc/test/openshift-e2e-gcp-crc-test-commands.sh

---

Side note, I doubt this script works correctly. When oc fails, the script doesn't loop: 
```
./wait-for-cluster.sh
...
+ oc delete pods --field-selector=status.phase=Failed -A
Unable to connect to the server: x509: certificate signed by unknown authority (possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate "kube-apiserver-lb-signer")
+ oc get pod --no-headers --all-namespaces
+ grep -v Running
+ grep -v Completed
+ grep -v Terminating
+ grep -v Pending
Unable to connect to the server: x509: certificate signed by unknown authority (possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate "kube-apiserver-lb-signer")
+ oc get co '-ojsonpath={.items[*].status.conditions[?(@.type=="Available")].status}'
+ grep -v True
Unable to connect to the server: x509: certificate signed by unknown authority (possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate "kube-apiserver-lb-signer")
``` 