### PR TITLE
Fix error for crictl stopp/rmp pods

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -324,9 +324,13 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo timedatectl set-ntp off
 # Enable the io.podman.socket service
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl enable io.podman.socket
 
-# Remove all the pods from the VM
-${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo crictl stopp $(sudo crictl pods -q)'
-${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'for i in {1..3}; do sudo crictl rmp $(sudo crictl pods -q) && break || sleep 2; done'
+# Remove all the pods except openshift-sdn from the VM
+pods=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo crictl pods -o json | jq '.items[] | select(.metadata.namespace != "openshift-sdn")' | jq -r .id)
+${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo crictl stopp ${pods}
+${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- "for i in {1..3}; do sudo crictl rmp "${pods}" && break || sleep 2; done"
+
+# Remove openshift-sdn pods also from the VM
+${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo crictl stopp $(sudo crictl pods -q) && sudo crictl rmp $(sudo crictl pods -q)'
 
 # Remove pull secret from the VM
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rm -f /var/lib/kubelet/config.json'


### PR DESCRIPTION
If the openshift-sdn pods are stop early then crictl not
able to stop any other pods and we see error in the CI around
stopping the pods and then removing it. With this PR we first
get all the pods id which are not openshift-sdn namespace and stop
them first and finally stop the sdn one.

- https://bugzilla.redhat.com/show_bug.cgi?id=1827022