### PR TITLE
Add the script run by the CI

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+./snc.sh
+if [[ $? -ne 0 ]]; then
+  exit 1
+fi
+# wait till the cluster is stable
+sleep 5m
+export KUBECONFIG=crc-tmp-install-data/auth/kubeconfig
+# Remove all the failed Pods
+oc delete pods --field-selector=status.phase=Failed -A
+# Wait till all the pods are either running or pending or completed or in terminating state
+while oc get pod --no-headers --all-namespaces | grep -v Running | grep -v Completed | grep -v Terminating | grep -v Pending; do
+   sleep 2
+done
+# Check the cluster operator output, status for available should be true for all operators
+while oc get co -ojsonpath='{.items[*].status.conditions[?(@.type=="Available")].status}' | grep -v True; do
+   sleep 2
+done
+# Run createdisk script
+export SNC_VALIDATE_CERT=false
+./createdisk.sh crc-tmp-install-data


### PR DESCRIPTION
Extracted from https://github.com/openshift/release/blob/431aac76304a21b1c290811441d8b12b9252450c/ci-operator/step-registry/code-ready/snc/e2e/test/code-ready-snc-e2e-test-commands.sh

This will allow us to define the CI script here instead of defining it in openshift/release repo.