### PR TITLE
Use a constant name for node name crc-abcde

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -388,6 +388,11 @@ ${YQ} write --inplace ${INSTALL_DIR}/install-config.yaml sshKey "$(cat id_rsa_cr
 # Create the manifests using the INSTALL_DIR
 ${OPENSHIFT_INSTALL} --dir ${INSTALL_DIR} create manifests || exit 1
 
+# Use a fixed node name
+OLD_INFRA_NAME=$(${YQ} read ${INSTALL_DIR}/manifests/cluster-infrastructure-02-config.yml 'status.infrastructureName')
+NEW_INFRA_NAME=$(${YQ} read install-config.yaml metadata.name)-abcde
+find ${INSTALL_DIR} -type f -exec sed -i "s/${OLD_INFRA_NAME}/${NEW_INFRA_NAME}/g"  {} \;
+
 # Add custom domain to cluster-ingress
 ${YQ} write --inplace ${INSTALL_DIR}/manifests/cluster-ingress-02-config.yml spec[domain] apps-${CRC_VM_NAME}.${BASE_DOMAIN}
 # Add master memory to 12 GB and 6 cpus 


### PR DESCRIPTION
It allows crc and consumers of snc to have a static DNS configuration.
It doesnt depend anymore of a random name picked by the installer.

---

Only few files contains the random name, it is faily easy to change.

```
crc-tmp-install-data/manifests/cluster-infrastructure-02-config.yml
15:  infrastructureName: crc-abcde

crc-tmp-install-data/openshift/99_openshift-cluster-api_master-machines-0.yaml
6:    machine.openshift.io/cluster-api-cluster: crc-abcde
9:  name: crc-abcde-master-0
27:      networkInterfaceName: crc-abcde
31:        baseVolumeID: crc-abcde-base
32:        poolName: crc-abcde

crc-tmp-install-data/openshift/99_openshift-cluster-api_worker-machineset-0.yaml
6:    machine.openshift.io/cluster-api-cluster: crc-abcde
9:  name: crc-abcde-worker-0
15:      machine.openshift.io/cluster-api-cluster: crc-abcde
16:      machine.openshift.io/cluster-api-machineset: crc-abcde-worker-0
21:        machine.openshift.io/cluster-api-cluster: crc-abcde
24:        machine.openshift.io/cluster-api-machineset: crc-abcde-worker-0
41:          networkInterfaceName: crc-abcde
45:            baseVolumeID: crc-abcde-base
46:            poolName: crc-abcde

``` 