### PR TITLE
Destroy the cluster at the end of the CI run

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -19,3 +19,6 @@ done
 # Run createdisk script
 export SNC_VALIDATE_CERT=false
 ./createdisk.sh crc-tmp-install-data
+
+# Destroy the cluster
+./openshift-install destroy cluster --dir crc-tmp-install-data


### PR DESCRIPTION
This is required if we want to use ci.sh in all openshift CI jobs, esp. https://github.com/openshift/release/blob/431aac76304a21b1c290811441d8b12b9252450c/ci-operator/step-registry/openshift/e2e/gcp/crc/test/openshift-e2e-gcp-crc-test-commands.sh.
