### PR TITLE
Add bundle name to metadata json

### DIFF
--- a/crc-bundle-info.json.sample
+++ b/crc-bundle-info.json.sample
@@ -6,6 +6,8 @@
   # Type of this bundle content
   # Currently the only valid type is 'snc' (which stands for 'single-node-cluster')
   "type": "snc",
+  # Name of the bundle
+  "name": "crc_libvirt_4.6.1",
   "buildInfo": {
     # Time this bundle was built
     "buildTime": "2019-04-23T14:55:32+00:00",

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -135,6 +135,7 @@ function update_json_description {
     diskSha256Sum=$(sha256sum $destDir/${CRC_VM_NAME}.qcow2 | awk '{print $1}')
 
     cat $srcDir/crc-bundle-info.json \
+        | ${JQ} ".name = \"${destDir}\"" \
         | ${JQ} '.clusterInfo.sshPrivateKeyFile = "id_rsa_crc"' \
         | ${JQ} '.clusterInfo.kubeConfig = "kubeconfig"' \
         | ${JQ} '.clusterInfo.kubeadminPasswordFile = "kubeadmin-password"' \


### PR DESCRIPTION
Currently the name used by crc is the directory name contained in the
crcbundle file. crc also guesses it from the crcbundle file, it takes
the name of the bundle without the extension.
Having a clear name property and the fact that the metadata file can be
read by only extracting the first bytes of the bundle, we can remove
this ambiguity.