### PR TITLE
Fix stopping of pods

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -334,7 +334,7 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl enable io.podman
 
 # Remove all the pods except openshift-sdn from the VM
 pods=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo crictl pods -o json | jq '.items[] | select(.metadata.namespace != "openshift-sdn")' | jq -r .id)
-${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- "sudo crictl stopp ${pods} || true"
+${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- "sudo crictl stopp "${pods}" || true"
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- "for i in {1..3}; do sudo crictl rmp "${pods}" && break || sleep 2; done || true"
 
 # Remove openshift-sdn pods also from the VM


### PR DESCRIPTION
If we don't wrap '${pods}' with '', the stopp command will only work
for the first pod:

Stopped sandbox fbddcddc0db75c5c5a31bd976a236ef2fac8a1289e43603643d68f799f1aa57c
bash: line 1: ba1001bb7736c6ba475e821a3170a642deb224b371894e580e9eb1ad3a3bee37: command not found
bash: line 2: 3eb6b47dbfe7e8d1ebe42308a8f3fbbcb29492e7a90836c131d34df5e060c087: command not found