### PR TITLE
BUG 1899459: Delete prometheus validation admission webhook

### DIFF
--- a/cvo_override.yaml
+++ b/cvo_override.yaml
@@ -56,3 +56,8 @@
     name: kube-storage-version-migrator-operator
     namespace: openshift-kube-storage-version-migrator-operator
     unmanaged: true
+  - kind: Deployment
+    group: apps/v1
+    name: etcd-quorum-guard
+    namespace: openshift-etcd
+    unmanaged: true

--- a/snc.sh
+++ b/snc.sh
@@ -433,6 +433,8 @@ delete_operator "deployment/prometheus-operator" "openshift-monitoring" "app.kub
 delete_operator "deployment/prometheus-adapter" "openshift-monitoring" "name=prometheus-adapter"
 delete_operator "statefulset/alertmanager-main" "openshift-monitoring" "app=alertmanager"
 ${OC} delete statefulset,deployment,daemonset --all -n openshift-monitoring
+# Delete prometheus rule application webhook
+${OC} delete validatingwebhookconfigurations prometheusrules.openshift.io
 
 # Delete the pods which are there in Complete state
 ${OC} delete pods -l 'app in (installer, pruner)' -n openshift-kube-apiserver

--- a/snc.sh
+++ b/snc.sh
@@ -467,5 +467,8 @@ ${OC} delete apiservice v1beta1.metrics.k8s.io
 # Scale route deployment from 2 to 1
 ${OC} scale --replicas=1 ingresscontroller/default -n openshift-ingress-operator
 
+# Scale etcd-quorum deployment from 3 to 1
+${OC} scale --replicas=1 deployment etcd-quorum-guard -n openshift-etcd
+
 # Set default route for registry CRD from false to true.
 ${OC} patch config.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge


### PR DESCRIPTION
Unsupported config is used to make etcd work during bootstrap but quorum is
still set to 3 nodes (replica) in the etcd-quorum-guard deployment. In case,
we want to make modification in the CVO override list after crc start then
reconciliation doesn't happen and it throw following error.

```
Error while reconciling 4.6.3: the workload openshift-etcd/etcd-quorum-guard has not yet successfully rolled out
```

With this patch etcd deployment is override to CVO and scale is set to 1 so that
there is no pending pod for quorum.