### PR TITLE
Replace unconditionnal module loading with udev rule

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -346,8 +346,9 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rpm-ostree install /home/
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- rm -fr /home/core/packages
 
 # Adding Hyper-V vsock support
+
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} 'sudo bash -x -s' <<EOF
-    echo hv_sock > /etc/modules-load.d/vsock.conf
+    echo 'CONST{virt}=="microsoft", RUN{builtin}+="kmod load hv_sock"' > /etc/udev/rules.d/90-crc-vsock.rules
 EOF
 
 # Add gvisor-tap-vsock service


### PR DESCRIPTION
hv_sock is only loadable when ran under hyper-v. Unconditionnally
loading it causes a warning to be shown when ssh'ing into the VM.
This udev rule will only trigger on hyper-v guests and load hv_sock.