### PR TITLE
Bump version of crc-bundle-info.json file

### DIFF
--- a/crc-bundle-info.json.sample
+++ b/crc-bundle-info.json.sample
@@ -2,7 +2,7 @@
   # Version of the bundle, used to denote format changes
   # Major is only increased changes incompatible with previous versions
   # Minor is increased for backwards-compatible changes
-  "version": "1.0",
+  "version": "1.1",
   # Type of this bundle content
   # Currently the only valid type is 'snc' (which stands for 'single-node-cluster')
   "type": "snc",

--- a/snc.sh
+++ b/snc.sh
@@ -154,7 +154,7 @@ function apply_auth_hack() {
 function create_json_description {
     openshiftInstallerVersion=$(${OPENSHIFT_INSTALL} version)
     sncGitHash=$(git describe --abbrev=4 HEAD 2>/dev/null || git rev-parse --short=4 HEAD)
-    echo {} | ${JQ} '.version = "1.0"' \
+    echo {} | ${JQ} '.version = "1.1"' \
             | ${JQ} '.type = "snc"' \
             | ${JQ} ".buildInfo.buildTime = \"$(date -u --iso-8601=seconds)\"" \
             | ${JQ} ".buildInfo.openshiftInstallerVersion = \"${openshiftInstallerVersion}\"" \


### PR DESCRIPTION
The addition of the name property is a new API. Consumers can use the
version field to determine if a name is available or not in the
metadata.

---

Each time we break the compatibility with the previous bundle, we should bump this number.