### PR TITLE
Changes to support OKD 4.6 and change SSH key from RSA to ECDSA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-id_rsa_crc
-id_rsa_crc.pub
+id_ecdsa_crc
+id_ecdsa_crc.pub
 crc-tmp-install-data
 openshift-install
 pull-secret

--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ Add the following lines in your `~/.ssh/config` file. You can then do `ssh maste
 Host master
     Hostname 192.168.126.11
     User core
-    IdentityFile <directory_to_cloned_repo>/id_rsa_crc
+    IdentityFile <directory_to_cloned_repo>/id_ecdsa_crc
     StrictHostKeyChecking no
     UserKnownHostsFile /dev/null
 
 Host bootstrap
     Hostname 192.168.126.10
     User core
-    IdentityFile <directory_to_cloned_repo>/id_rsa_crc
+    IdentityFile <directory_to_cloned_repo>/id_ecdsa_crc
     StrictHostKeyChecking no
     UserKnownHostsFile /dev/null
 ```

--- a/crc-bundle-info.json.sample
+++ b/crc-bundle-info.json.sample
@@ -28,7 +28,7 @@
     "appsDomain": "apps-crc.testing",
     # Name of a file containing an SSH private key which can be used to connect to
     # the cluster nodes
-    "sshPrivateKeyFile": "id_rsa_crc",
+    "sshPrivateKeyFile": "id_ecdsa_crc",
     # Name of the kubeconfig file stored in the bundle
     "kubeConfig": "kubeconfig",
     # Name of the file containing the kubeadmin password for use in the

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -300,7 +300,11 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rm -f /var/lib/kubelet/co
 if [[ ${OKD_VERSION} != "none" ]]
 then
     # Install the hyperV and libvarlink-util rpms to VM
+    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora.repo'
+    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora-updates.repo'
     ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rpm-ostree install --allow-inactive hyperv-daemons libvarlink-util'
+    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora.repo'
+    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora-updates.repo'
 else
     # Download the hyperV daemons and libvarlink-util dependency on host
     mkdir $1/packages

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -282,8 +282,8 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl unmask chronyd
 # Disable the chronyd service
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl disable chronyd
 
-# Enable the io.podman.socket service
-    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl enable io.podman.socket
+# Enable the podman.socket service for API V2
+    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl enable podman.socket
 
 # Remove all the pods except openshift-sdn from the VM
 pods=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo crictl pods -o json | jq '.items[] | select(.metadata.namespace != "openshift-sdn")' | jq -r .id)

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -7,8 +7,8 @@ export LANG=C
 
 source tools.sh
 
-SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_crc"
-SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_crc"
+SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
+SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
 OC=./openshift-clients/linux/oc
 DEVELOPER_USER_PASS='developer:$2y$05$paX6Xc9AiLa6VT7qr2VvB.Qi.GJsaqS80TR3Kb78FEIlIL0YyBuyS'
 # If the user set OKD_VERSION in the environment, then use it to override OPENSHIFT_VERSION, set BASE_OS, and set USE_LUKS
@@ -138,7 +138,7 @@ function update_json_description {
 
     cat $srcDir/crc-bundle-info.json \
         | ${JQ} ".name = \"${destDir}\"" \
-        | ${JQ} '.clusterInfo.sshPrivateKeyFile = "id_rsa_crc"' \
+        | ${JQ} '.clusterInfo.sshPrivateKeyFile = "id_ecdsa_crc"' \
         | ${JQ} '.clusterInfo.kubeConfig = "kubeconfig"' \
         | ${JQ} '.clusterInfo.kubeadminPasswordFile = "kubeadmin-password"' \
         | ${JQ} '.nodes[0].kind[0] = "master"' \
@@ -179,8 +179,8 @@ function copy_additional_files {
     cp $1/auth/kube* $destDir/
 
     # Copy the master public key
-    cp id_rsa_crc $destDir/
-    chmod 400 $destDir/id_rsa_crc
+    cp id_ecdsa_crc $destDir/
+    chmod 400 $destDir/id_ecdsa_crc
 
     # Copy oc client
     cp openshift-clients/linux/oc $destDir/
@@ -197,7 +197,7 @@ function generate_hyperkit_directory {
 
     cp $srcDir/kubeadmin-password $destDir/
     cp $srcDir/kubeconfig $destDir/
-    cp $srcDir/id_rsa_crc $destDir/
+    cp $srcDir/id_ecdsa_crc $destDir/
     cp $srcDir/${CRC_VM_NAME}.qcow2 $destDir/
     cp $tmpDir/vmlinuz-${kernel_release} $destDir/
     cp $tmpDir/initramfs-${kernel_release}.img $destDir/
@@ -220,7 +220,7 @@ function generate_hyperv_directory {
 
     cp $srcDir/kubeadmin-password $destDir/
     cp $srcDir/kubeconfig $destDir/
-    cp $srcDir/id_rsa_crc $destDir/
+    cp $srcDir/id_ecdsa_crc $destDir/
 
     # Copy oc client
     cp openshift-clients/windows/oc.exe $destDir/
@@ -283,7 +283,7 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl unmask chronyd
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl disable chronyd
 
 # Enable the io.podman.socket service
-${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl enable io.podman.socket
+    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl enable io.podman.socket
 
 # Remove all the pods except openshift-sdn from the VM
 pods=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo crictl pods -o json | jq '.items[] | select(.metadata.namespace != "openshift-sdn")' | jq -r .id)

--- a/snc.sh
+++ b/snc.sh
@@ -24,7 +24,7 @@ INSTALL_DIR=crc-tmp-install-data
 CRC_VM_NAME=${CRC_VM_NAME:-crc}
 BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
 CRC_PV_DIR="/mnt/pv-data"
-SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_rsa_crc"
+SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
 MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp}
 CERT_ROTATION=${SNC_DISABLE_CERT_ROTATION:-enabled}
 
@@ -331,9 +331,9 @@ fi
 # Destroy an existing cluster and resources
 ${OPENSHIFT_INSTALL} --dir ${INSTALL_DIR} destroy cluster ${OPENSHIFT_INSTALL_EXTRA_ARGS} || echo "failed to destroy previous cluster.  Continuing anyway"
 # Generate a new ssh keypair for this cluster
-
-rm id_rsa_crc* || true
-ssh-keygen -N "" -f id_rsa_crc -C "core"
+# Create a 521bit ECDSA Key
+rm id_ecdsa_crc* || true
+ssh-keygen -t ecdsa -b 521 -N "" -f id_ecdsa_crc -C "core"
 
 # Use dnsmasq as dns in network manager config
 if ! grep -iqR dns=dnsmasq /etc/NetworkManager/conf.d/ ; then
@@ -374,7 +374,7 @@ ${YQ} write --inplace ${INSTALL_DIR}/install-config.yaml metadata.name ${CRC_VM_
 ${YQ} write --inplace ${INSTALL_DIR}/install-config.yaml compute[0].replicas 0
 ${YQ} write --inplace ${INSTALL_DIR}/install-config.yaml pullSecret "@HIDDEN_PULL_SECRET@"
 replace_pull_secret ${INSTALL_DIR}/install-config.yaml
-${YQ} write --inplace ${INSTALL_DIR}/install-config.yaml sshKey "$(cat id_rsa_crc.pub)"
+${YQ} write --inplace ${INSTALL_DIR}/install-config.yaml sshKey "$(cat id_ecdsa_crc.pub)"
 
 # Create the manifests using the INSTALL_DIR
 ${OPENSHIFT_INSTALL} --dir ${INSTALL_DIR} create manifests || exit 1


### PR DESCRIPTION
io.podman.socket changed to podman.socket for FCOS 33
enable fedora and fedora-updates repos for hyperV driver in FCOS 33
change rsa key to ecdsa for SSH for both FCOS 33 and RHCOS

revolves https://github.com/code-ready/crc/issues/1747 for snc bundle
**Note:** this will break crc builds without: https://github.com/code-ready/crc/pull/1757

