### PR TITLE
Optimize ppc64le (request for comments)

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -196,6 +196,41 @@ function generate_hyperkit_directory {
         >$destDir/crc-bundle-info.json
 }
 
+function prepare_hyperV {
+
+        if [[ ${OKD_VERSION} != "none" ]]; then
+                # Install the hyperV and libvarlink-util rpms to VM
+                ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora.repo'
+                ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora-updates.repo'
+                ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rpm-ostree install --allow-inactive hyperv-daemons libvarlink-util'
+                ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora.repo'
+                ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora-updates.repo'
+        else
+                # Download the hyperV daemons and libvarlink-util dependency on host
+                mkdir $1/packages
+                sudo yum install -y --downloadonly --downloaddir $1/packages hyperv-daemons libvarlink-util
+
+                # SCP the downloaded rpms to VM
+                ${SCP} -r $1/packages core@api.${CRC_VM_NAME}.${BASE_DOMAIN}:/home/core/
+
+                # Install the hyperV and libvarlink-util rpms to VM
+                ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rpm-ostree install /home/core/packages/*.rpm'
+
+                # Remove the packages from VM
+                ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- rm -fr /home/core/packages
+
+                # Cleanup up packages
+                rm -fr $1/packages
+        fi
+
+        # Adding Hyper-V vsock support
+
+        ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} 'sudo bash -x -s' <<EOF
+            echo 'CONST{virt}=="microsoft", RUN{builtin}+="kmod load hv_sock"' > /etc/udev/rules.d/90-crc-vsock.rules
+EOF
+
+}
+
 function generate_hyperv_directory {
     local srcDir=$1
     local destDir=$2

--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -196,7 +196,7 @@ function generate_hyperkit_directory {
         >$destDir/crc-bundle-info.json
 }
 
-function prepare_hyperV {
+function prepare_hyperV() {
 
         if [[ ${OKD_VERSION} != "none" ]]; then
                 # Install the hyperV and libvarlink-util rpms to VM

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -90,7 +90,7 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rm -f /var/lib/kubelet/co
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo find /var/log/ -iname "*.log" -exec rm -f {} \;'
 
 if [ "${ARCH}" != "ppc64le" ]; then
-        prepare_hyperV
+        prepare_hyperV "$1"
 
         # Adding Hyper-V vsock support
         ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} 'sudo bash -x -s' <<EOF

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -89,37 +89,14 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rm -f /var/lib/kubelet/co
 # Remove audit logs
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo find /var/log/ -iname "*.log" -exec rm -f {} \;'
 
-if [[ ${OKD_VERSION} != "none" ]]
-then
-    # Install the hyperV rpms to VM
-    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora.repo'
-    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora-updates.repo'
-    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rpm-ostree install --allow-inactive hyperv-daemons'
-    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora.repo'
-    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora-updates.repo'
-else
-    # Download the hyperV daemons dependency on host
-    mkdir $1/packages
-    sudo yum install -y --downloadonly --downloaddir $1/packages hyperv-daemons
+if [ "${ARCH}" != "ppc64le" ]; then
+        prepare_hyperV
 
-    # SCP the downloaded rpms to VM
-    ${SCP} -r $1/packages core@api.${CRC_VM_NAME}.${BASE_DOMAIN}:/home/core/
-
-    # Install the hyperV rpms to VM
-    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rpm-ostree install /home/core/packages/*.rpm'
-
-    # Remove the packages from VM
-    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- rm -fr /home/core/packages
-
-    # Cleanup up packages
-    rm -fr $1/packages
-fi
-
-# Adding Hyper-V vsock support
-
-${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} 'sudo bash -x -s' <<EOF
+        # Adding Hyper-V vsock support
+        ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} 'sudo bash -x -s' <<EOF
     echo 'CONST{virt}=="microsoft", RUN{builtin}+="kmod load hv_sock"' > /etc/udev/rules.d/90-crc-vsock.rules
 EOF
+fi
 
 # Add gvisor-tap-vsock service
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} 'sudo bash -x -s' <<EOF
@@ -187,24 +164,26 @@ copy_additional_files "$1" "$libvirtDestDir"
 
 tar cSf - --sort=name "$libvirtDestDir" | xz --threads=0 >"$libvirtDestDir.$crcBundleSuffix"
 
-# HyperKit image generation
-# This must be done after the generation of libvirt image as it reuse some of
-# the content of $libvirtDestDir
-hyperkitDestDir="crc_hyperkit_${destDirSuffix}"
-mkdir "$hyperkitDestDir"
-generate_hyperkit_directory "$libvirtDestDir" "$hyperkitDestDir" "$1" "$kernel_release" "$kernel_cmd_line"
+if [ "${ARCH}" != "ppc64le" ]; then
+        # HyperKit image generation
+        # This must be done after the generation of libvirt image as it reuse some of
+        # the content of $libvirtDestDir
+        hyperkitDestDir="crc_hyperkit_${destDirSuffix}"
+        mkdir "$hyperkitDestDir"
+        generate_hyperkit_directory "$libvirtDestDir" "$hyperkitDestDir" "$1" "$kernel_release" "$kernel_cmd_line"
 
-tar cSf - --sort=name "$hyperkitDestDir" | xz --threads=0 >"$hyperkitDestDir.$crcBundleSuffix"
+        tar cSf - --sort=name "$hyperkitDestDir" | xz --threads=0 >"$hyperkitDestDir.$crcBundleSuffix"
 
-# HyperV image generation
-#
-# This must be done after the generation of libvirt image as it reuses some of
-# the content of $libvirtDestDir
-hypervDestDir="crc_hyperv_${destDirSuffix}"
-mkdir "$hypervDestDir"
-generate_hyperv_directory "$libvirtDestDir" "$hypervDestDir"
+        # HyperV image generation
+        #
+        # This must be done after the generation of libvirt image as it reuses some of
+        # the content of $libvirtDestDir
+        hypervDestDir="crc_hyperv_${destDirSuffix}"
+        mkdir "$hypervDestDir"
+        generate_hyperv_directory "$libvirtDestDir" "$hypervDestDir"
 
-tar cSf - --sort=name "$hypervDestDir" | xz --threads=0 >"$hypervDestDir.$crcBundleSuffix"
+        tar cSf - --sort=name "$hypervDestDir" | xz --threads=0 >"$hypervDestDir.$crcBundleSuffix"
+fi
 
 # Cleanup up vmlinux/initramfs files
 rm -fr "$1/vmlinuz*" "$1/initramfs*"

--- a/shellcheck.sh
+++ b/shellcheck.sh
@@ -2,6 +2,7 @@
 set -exuo pipefail
 
 SHELLCHECK=${SHELLCHECK:-shellcheck}
+#TODO: address ppc64le support
 
 if ! "${SHELLCHECK}" -V; then
     if [[ ! -e SHELLCHECK ]]; then

--- a/snc-library.sh
+++ b/snc-library.sh
@@ -10,6 +10,29 @@ function preflight_failure() {
         fi
 }
 
+function download_oc_binary() {
+        mkdir -p openshift-clients/linux
+
+        if [ "${ARCH}" != "ppc64le" ]; then
+                mkdir openshift-clients/mac openshift-clients/windows
+        fi
+
+        if [[ ${OKD_VERSION} != "none" ]]; then
+                curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/linux oc
+                if [ "${ARCH}" != "ppc64le" ]; then
+                        curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-mac-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/mac oc
+                        curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-windows-${OPENSHIFT_RELEASE_VERSION}.zip" > openshift-clients/windows/oc.zip
+                fi
+        else
+                curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux.tar.gz" | tar -zx -C openshift-clients/linux oc
+                if [ "${ARCH}" != "ppc64le" ]; then
+                        curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-mac.tar.gz" | tar -zx -C openshift-clients/mac oc
+                        curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-windows.zip" > openshift-clients/windows/oc.zip
+                        ${UNZIP} -o -d openshift-clients/windows/ openshift-clients/windows/oc.zip
+                fi
+        fi
+}
+
 function run_preflight_checks() {
         echo "Checking libvirt and DNS configuration"
 

--- a/snc.sh
+++ b/snc.sh
@@ -43,20 +43,14 @@ else
     fi
 fi
 
-# Download the oc binary for all platforms
-mkdir -p openshift-clients/linux openshift-clients/mac openshift-clients/windows
-if [[ ${OKD_VERSION} != "none" ]]
-then
-    curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/linux oc
-    curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-mac-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/mac oc
-    curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-windows-${OPENSHIFT_RELEASE_VERSION}.zip" > openshift-clients/windows/oc.zip
+# Download the oc binary for the specific architecture
+download_oc_binary
+if [ "$?" -eq 0 ]; then
+        OC=./openshift-clients/linux/oc
 else
-    curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux.tar.gz" | tar -zx -C openshift-clients/linux oc
-    curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-mac.tar.gz" | tar -zx -C openshift-clients/mac oc
-    curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-windows.zip" > openshift-clients/windows/oc.zip
+        echo "Error downloading oc binary."
+        exit 1
 fi
-${UNZIP} -o -d openshift-clients/windows/ openshift-clients/windows/oc.zip
-OC=./openshift-clients/linux/oc
 
 run_preflight_checks
 

--- a/tools.sh
+++ b/tools.sh
@@ -61,6 +61,7 @@ fi
 if ! which ${DIG}; then
     sudo yum -y install /usr/bin/dig
 fi
+# only windows oc binary needs to be unzipped
 if ! which ${UNZIP}; then
     sudo yum -y install /usr/bin/unzip
 fi


### PR DESCRIPTION
Since creating tools and library files, this commit attempts to address the multi-arch optimizations for ppc64le, aka POWER hardware. 

- Create download_oc_binary() in snc-library to obtain only the binaries needed for the specific arch. Saves some time in snc.sh
- Creates prepare_hyperV() in createdisk-library to optimize crc bundle creation for ppc64le. Even tho these hyperV changes are not going to happen on ppc64le, the master VM will still be restarted.
- Made a TODO in shellcheck.sh since there is not a stable release of shellcheck for ppc64le. Will be needed for ci in the future.
- Added comment about unzip package since only needed for windows.

Addresses PR #263 

I'm hoping this PR can start the discussion about how to address multi-arch support going forward with the 4.7 release utilizing the power box at osu. I'm available to chat :) 
