### PR TITLE
Clean up child processes more reliably

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -9,7 +9,7 @@ source tools.sh
 source snc-library.sh
 
 # kill all the child processes for this script when it exits
-trap 'jobs=($(jobs -p)); ((${#jobs})) && kill "${jobs[@]}" || true; exit 0' TERM
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
 
 # If the user set OKD_VERSION in the environment, then use it to override OPENSHIFT_VERSION, MIRROR, and OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE
 # Unless, those variables are explicitly set as well.


### PR DESCRIPTION
The current code didn't seem to clean up children on exit. Also,
if there were no children to kill, the following error message
showed up on the console:
./snc.sh: line 1: jobs: unbound variable

Borrowed the code from [1]. This seems to reliably kill all
children processes on interrupt or exit and doesn't generate any
error messages.

[1] https://stackoverflow.com/questions/360201/how-do-i-kill-background-processes-jobs-when-my-shell-script-exits/2173421#2173421