### PR TITLE
Change clusterNetwork CIDR once more

### DIFF
--- a/install-config.yaml
+++ b/install-config.yaml
@@ -19,13 +19,13 @@ metadata:
   name: crc
 networking:
   clusterNetwork:
-  - cidr: 10.116.0.0/14
+  - cidr: 10.217.0.0/22
     hostPrefix: 23
   machineNetwork:
   - cidr: 192.168.126.0/24
   networkType: OpenShiftSDN
   serviceNetwork:
-  - 172.25.0.0/16
+  - 10.217.4.0/23
 platform:
   libvirt:
     URI: qemu+tcp://192.168.122.1/system


### PR DESCRIPTION
This was initially changed because it was causing issues when running
crc in an OpenShift cluster.
However the new one causes collisions in a different environment.

Let's try a 3rd different value and see if we are lucky this time :)

I picked:
- an odd number
- bigger than 200

in the hope that sysadmins are less likely to see this as a good value
to use for internal networks.

Note: no problem dropping this if we feel there is no added value :)