### PR TITLE
Update trap inline to get exit code of the process

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -9,7 +9,7 @@ source tools.sh
 source snc-library.sh
 
 # kill all the child processes for this script when it exits
-trap 'jobs=($(jobs -p)); [ -n "${jobs-}" ] && ((${#jobs})) && kill "${jobs[@]}" || true; exit 0' EXIT
+trap 'jobs=($(jobs -p)); [ -n "${jobs-}" ] && ((${#jobs})) && kill "${jobs[@]}" || true' EXIT
 
 # If the user set OKD_VERSION in the environment, then use it to override OPENSHIFT_VERSION, MIRROR, and OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE
 # Unless, those variables are explicitly set as well.


### PR DESCRIPTION
Currently the exit code is `0` even snc process is failed
because of `exit 0` as part of trap inline.

```
$ cat test.sh

set -exuo pipefail

trap 'jobs=($(jobs -p)); [ -n "${jobs-}" ] && ((${#jobs})) && kill "${jobs[@]}" || true; exit 0' EXIT

function test_trap() {
        while true; do
            sleep 3
        break
        done
        echo "This just a check"
}

test_trap &

sleep 4
foobar

$ ./test.sh
./test.sh: line 18: foobar: command not found
+ jobs=($(jobs -p))
++ jobs -p
+ '[' -n 2191906 ']'
+ (( 7 ))
+ kill 2191906
./test.sh: line 1: kill: (2191906) - No such process
+ true
+ exit 0

$ echo $?
0
```

fixes: #312