### PR TITLE
Remove SNC_VALIDATE_CERT env from CI

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -24,7 +24,6 @@ done
 
 set -exuo pipefail
 # Run createdisk script
-export SNC_VALIDATE_CERT=false
 ./createdisk.sh crc-tmp-install-data
 set +exuo pipefail
 


### PR DESCRIPTION
This was helpful because initially we didn't have the way to do
cert rotation instead waiting for 24 hour, which is changed recently
and now it is not required.

 commit-id 9155345