### PR TITLE
Set kubelet node-ip with an environment file

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -153,7 +153,11 @@ ${SCP} core@api.${CRC_VM_NAME}.${BASE_DOMAIN}:/boot/ostree/${BASE_OS}-${ostree_h
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- "sudo nmcli conn add type dummy ifname eth10 con-name internalEtcd ip4 ${INTERNAL_IP}/24  && sudo nmcli conn up internalEtcd"
 
 # Add internalIP as node IP for kubelet systemd unit file
-${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- "sudo sed -i.back '/kubelet /a\      --node-ip="${INTERNAL_IP}" \\\' /etc/systemd/system/kubelet.service"
+# More details at https://bugzilla.redhat.com/show_bug.cgi?id=1872632
+${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} 'sudo bash -x -s' <<EOF
+    echo '[Service]' > /etc/systemd/system/kubelet.service.d/80-nodeip.conf
+    echo 'Environment=KUBELET_NODE_IP="${INTERNAL_IP}"' >> /etc/systemd/system/kubelet.service.d/80-nodeip.conf
+EOF
 
 # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1729603
 # TODO: Should be removed once latest podman available or the fix is backported.


### PR DESCRIPTION
OpenShift 4.6 added the flag --node-ip in the kubelet systemd unit.
SNC was already adding it at the very beginning. It works most of the
time but I suspect it is just luck and it might fail if the dummy
interface is not ready or so.

This change forces the node-ip to the value we want. The suggested env
file in the kubelet configuration is not working as expected.
I use here the same workaround as the bugzilla 1872632.

Related to https://github.com/code-ready/crc/issues/1888