### PR TITLE
createdisk: Compress bundle using zstd rather than xz

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -221,3 +221,9 @@ function generate_hyperv_directory {
         | ${JQ} '.driverInfo.name = "hyperv"' \
         >$destDir/crc-bundle-info.json
 }
+
+function create_tarball {
+    local dirName=$1
+
+    tar cSf - --sort=name "$dirName" | xz --threads=0 >"$dirName".crcbundle"
+}

--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -225,5 +225,5 @@ function generate_hyperv_directory {
 function create_tarball {
     local dirName=$1
 
-    tar cSf - --sort=name "$dirName" | xz --threads=0 >"$dirName".crcbundle"
+    tar cSf - --sort=name "$dirName" | ${ZSTD} --no-progress --ultra -22 --threads=0 -o "$dirName".crcbundle
 }

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -174,9 +174,6 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo journalctl --vacuum-time=
 # Shutdown the VM
 shutdown_vm ${VM_PREFIX}
 
-# instead of .tar.xz we use .crcbundle
-crcBundleSuffix=crcbundle
-
 # libvirt image generation
 get_dest_dir
 destDirSuffix="${DEST_DIR}"
@@ -185,10 +182,8 @@ libvirtDestDir="crc_libvirt_${destDirSuffix}"
 mkdir "$libvirtDestDir"
 
 create_qemu_image "$libvirtDestDir"
-
 copy_additional_files "$1" "$libvirtDestDir"
-
-tar cSf - --sort=name "$libvirtDestDir" | xz --threads=0 >"$libvirtDestDir.$crcBundleSuffix"
+create_tarball "$libvirtDestDir"
 
 # HyperKit image generation
 # This must be done after the generation of libvirt image as it reuse some of
@@ -196,8 +191,7 @@ tar cSf - --sort=name "$libvirtDestDir" | xz --threads=0 >"$libvirtDestDir.$crcB
 hyperkitDestDir="crc_hyperkit_${destDirSuffix}"
 mkdir "$hyperkitDestDir"
 generate_hyperkit_directory "$libvirtDestDir" "$hyperkitDestDir" "$1" "$kernel_release" "$kernel_cmd_line"
-
-tar cSf - --sort=name "$hyperkitDestDir" | xz --threads=0 >"$hyperkitDestDir.$crcBundleSuffix"
+create_tarball "$hyperkitDestDir"
 
 # HyperV image generation
 #
@@ -206,8 +200,7 @@ tar cSf - --sort=name "$hyperkitDestDir" | xz --threads=0 >"$hyperkitDestDir.$cr
 hypervDestDir="crc_hyperv_${destDirSuffix}"
 mkdir "$hypervDestDir"
 generate_hyperv_directory "$libvirtDestDir" "$hypervDestDir"
-
-tar cSf - --sort=name "$hypervDestDir" | xz --threads=0 >"$hypervDestDir.$crcBundleSuffix"
+create_tarball "$hypervDestDir"
 
 # Cleanup up vmlinux/initramfs files
 rm -fr "$1/vmlinuz*" "$1/initramfs*"

--- a/tools.sh
+++ b/tools.sh
@@ -11,6 +11,7 @@ XMLLINT=${XMLLINT:-xmllint}
 
 DIG=${DIG:-dig}
 UNZIP=${UNZIP:-unzip}
+ZSTD=${ZSTD:-zstd}
 
 ARCH=$(uname -m)
 
@@ -63,6 +64,9 @@ if ! which ${DIG}; then
 fi
 if ! which ${UNZIP}; then
     sudo yum -y install /usr/bin/unzip
+fi
+if ! which ${ZSTD}; then
+    sudo yum -y install /usr/bin/zstd
 fi
 
 function retry {


### PR DESCRIPTION
It's both more efficient space-wise and faster to decompress:

   When compressed with `zstd --ultra -22 -T0`, the 4.6.9 bundle is 2.2G in 
   size, and uncompresses in about 1 minute. The xz-compressed bundle is 2.6G
   in size, and takes 3 minutes to uncompress.

   This requires crc-side support: https://github.com/code-ready/crc/pull/1905