### PR TITLE
#321 set the correct bundle name for non-libvirt bundles

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -189,6 +189,7 @@ function generate_hyperkit_directory {
 
     # Update the bundle metadata info
     cat $srcDir/crc-bundle-info.json \
+        | ${JQ} ".name = \"${destDir}\"" \
         | ${JQ} ".nodes[0].kernel = \"vmlinuz-${kernel_release}\"" \
         | ${JQ} ".nodes[0].initramfs = \"initramfs-${kernel_release}.img\"" \
         | ${JQ} ".nodes[0].kernelCmdLine = \"${kernel_cmd_line}\"" \
@@ -213,6 +214,7 @@ function generate_hyperv_directory {
     diskSha256Sum=$(sha256sum $destDir/${CRC_VM_NAME}.vhdx | awk '{print $1}')
 
     cat $srcDir/crc-bundle-info.json \
+        | ${JQ} ".name = \"${destDir}\"" \
         | ${JQ} ".nodes[0].diskImage = \"${CRC_VM_NAME}.vhdx\"" \
         | ${JQ} ".storage.diskImages[0].name = \"${CRC_VM_NAME}.vhdx\"" \
         | ${JQ} '.storage.diskImages[0].format = "vhdx"' \


### PR DESCRIPTION
Hyperkit and hyper-v directories are generated based on libvirt
directory.
The JSON name was set once, when creating libvirt directory.