### PR TITLE
Add CRC_ZSTD_EXTRA_FLAGS env variable to change zstd options for CI

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -227,5 +227,5 @@ function generate_hyperv_directory {
 function create_tarball {
     local dirName=$1
 
-    tar cSf - --sort=name "$dirName" | ${ZSTD} --no-progress --ultra -22 --threads=0 -o "$dirName".crcbundle
+    tar cSf - --sort=name "$dirName" | ${ZSTD} --no-progress ${CRC_ZSTD_EXTRA_FLAGS} --threads=0 -o "$dirName".crcbundle
 }

--- a/tools.sh
+++ b/tools.sh
@@ -12,6 +12,7 @@ XMLLINT=${XMLLINT:-xmllint}
 DIG=${DIG:-dig}
 UNZIP=${UNZIP:-unzip}
 ZSTD=${ZSTD:-zstd}
+CRC_ZSTD_EXTRA_FLAGS=${CRC_ZSTD_EXTRA_FLAGS:-"--ultra -22"}
 
 ARCH=$(uname -m)
 


### PR DESCRIPTION
This option will help us to provide different flag for zstd when running
in the CI to generate bundles fast.