### PR TITLE
Use different zstd option for CI

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -24,6 +24,7 @@ done
 
 set -exuo pipefail
 # Run createdisk script
+export CRC_ZSTD_EXTRA_FLAGS="-10 --long"
 ./createdisk.sh crc-tmp-install-data
 set +exuo pipefail
 


### PR DESCRIPTION
On openshift CI side the bundle creation takes lot of
time which makes CI to abort due to time out.