### PR TITLE
Create $ENV_TYPE and function download_oc() 

### DIFF
--- a/snc-library.sh
+++ b/snc-library.sh
@@ -10,6 +10,22 @@ function preflight_failure() {
         fi
 }
 
+function download_oc() {
+    mkdir -p openshift-clients/linux 
+    curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/linux oc
+
+    case "${ENV_TYPE}" in
+        "MACOS")
+            mkdir -p openshift-clients/mac 
+            curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-mac-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/mac oc;;
+        "WINDOWS")
+            mkdir -p openshift-clients/windows
+            curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-windows-${OPENSHIFT_RELEASE_VERSION}.zip" > openshift-clients/windows/oc.zip
+            ${UNZIP} -o -d openshift-clients/windows/ openshift-clients/windows/oc.zip;;
+    esac
+}
+
+
 function run_preflight_checks() {
         echo "Checking libvirt and DNS configuration"
 

--- a/snc.sh
+++ b/snc.sh
@@ -43,12 +43,8 @@ else
     fi
 fi
 
-# Download the oc binary for all platforms
-mkdir -p openshift-clients/linux openshift-clients/mac openshift-clients/windows
-curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/linux oc
-curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-mac-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/mac oc
-curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-windows-${OPENSHIFT_RELEASE_VERSION}.zip" > openshift-clients/windows/oc.zip
-${UNZIP} -o -d openshift-clients/windows/ openshift-clients/windows/oc.zip
+# Download the oc binary for specific OS environment
+download_oc
 OC=./openshift-clients/linux/oc
 
 run_preflight_checks

--- a/tools.sh
+++ b/tools.sh
@@ -16,6 +16,19 @@ CRC_ZSTD_EXTRA_FLAGS=${CRC_ZSTD_EXTRA_FLAGS:-"--ultra -22"}
 
 ARCH=$(uname -m)
 
+# Set the environment type based off the kernel name. 
+# NOTE: the kernel type is not the same as $OSTYPE
+case "$(uname -s)" in
+    Darwin*|darwin*)
+        ENV_TYPE="MACOS";;
+    Linux)
+        ENV_TYPE="LINUX";;
+    CYGWIN*|MINGW32*|MSYS*|MINGW*)
+        ENV_TYPE="WINDOWS";;
+    *)
+        echo "SNC runs on Linux, Windows, or Mac OS."
+        return 1;;
+esac
 
 yq_ARCH=${ARCH}
 # yq and install_config.yaml use amd64 as arch for x86_64
@@ -55,6 +68,11 @@ if ! rpm -q libguestfs-xfs; then
     sudo yum install libguestfs-xfs
 fi
 
+if [ "${ENV_TYPE}" == "WINDOWS" ];then
+    if ! which ${UNZIP}; then
+        sudo yum -y install /usr/bin/unzip
+    fi
+fi
 
 if ! which ${XMLLINT}; then
     sudo yum -y install /usr/bin/xmllint
@@ -63,9 +81,7 @@ fi
 if ! which ${DIG}; then
     sudo yum -y install /usr/bin/dig
 fi
-if ! which ${UNZIP}; then
-    sudo yum -y install /usr/bin/unzip
-fi
+
 if ! which ${ZSTD}; then
     sudo yum -y install /usr/bin/zstd
 fi


### PR DESCRIPTION
The ENV_TYPE variable is initialized based off the type of kernel running in order to determine if this is Linux, Windows, or Mac OS.

This is not the same value as the global env $OSTYPE.

download_oc() downloads the specific oc binary for the OS that is running. $OC is still set in snc.sh with the Linux oc file

Since UNZIP is only needed to extract the windows oc binary, first check if the environment is WINDOWS in tools.sh

Sorry I had to make another branch - my git tree was messed up. This PR is to address the discussion here: https://github.com/code-ready/snc/pull/323#pullrequestreview-582275789