### PR TITLE
Add SNC_GENERATE_{MACOS,WINDOWS}_BUNDLE

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -170,13 +170,14 @@ function copy_additional_files {
     eventually_add_pull_secret $destDir
 }
 
-function generate_hyperkit_directory {
+function generate_hyperkit_bundle {
     local srcDir=$1
     local destDir=$2
     local tmpDir=$3
     local kernel_release=$4
     local kernel_cmd_line=$5
 
+    mkdir "$destDir"
     cp $srcDir/kubeadmin-password $destDir/
     cp $srcDir/kubeconfig $destDir/
     cp $srcDir/id_ecdsa_crc $destDir/
@@ -195,11 +196,15 @@ function generate_hyperkit_directory {
         | ${JQ} ".nodes[0].kernelCmdLine = \"${kernel_cmd_line}\"" \
         | ${JQ} '.driverInfo.name = "hyperkit"' \
         >$destDir/crc-bundle-info.json
+
+    create_tarball "$destDir"
 }
 
-function generate_hyperv_directory {
+function generate_hyperv_bundle {
     local srcDir=$1
     local destDir=$2
+
+    mkdir "$destDir"
 
     cp $srcDir/kubeadmin-password $destDir/
     cp $srcDir/kubeconfig $destDir/
@@ -222,6 +227,8 @@ function generate_hyperv_directory {
         | ${JQ} ".storage.diskImages[0].sha256sum = \"${diskSha256Sum}\"" \
         | ${JQ} '.driverInfo.name = "hyperv"' \
         >$destDir/crc-bundle-info.json
+
+    create_tarball "$destDir"
 }
 
 function create_tarball {

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -186,21 +186,21 @@ copy_additional_files "$1" "$libvirtDestDir"
 create_tarball "$libvirtDestDir"
 
 # HyperKit image generation
-# This must be done after the generation of libvirt image as it reuse some of
+# This must be done after the generation of libvirt image as it reuses some of
 # the content of $libvirtDestDir
-hyperkitDestDir="crc_hyperkit_${destDirSuffix}"
-mkdir "$hyperkitDestDir"
-generate_hyperkit_directory "$libvirtDestDir" "$hyperkitDestDir" "$1" "$kernel_release" "$kernel_cmd_line"
-create_tarball "$hyperkitDestDir"
+if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then
+    hyperkitDestDir="crc_hyperkit_${destDirSuffix}"
+    generate_hyperkit_bundle "$libvirtDestDir" "$hyperkitDestDir" "$1" "$kernel_release" "$kernel_cmd_line"
+fi
 
 # HyperV image generation
 #
 # This must be done after the generation of libvirt image as it reuses some of
 # the content of $libvirtDestDir
-hypervDestDir="crc_hyperv_${destDirSuffix}"
-mkdir "$hypervDestDir"
-generate_hyperv_directory "$libvirtDestDir" "$hypervDestDir"
-create_tarball "$hypervDestDir"
+if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ]; then
+    hypervDestDir="crc_hyperv_${destDirSuffix}"
+    generate_hyperv_bundle "$libvirtDestDir" "$hypervDestDir"
+fi
 
 # Cleanup up vmlinux/initramfs files
 rm -fr "$1/vmlinuz*" "$1/initramfs*"

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -88,37 +88,9 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rm -f /var/lib/kubelet/co
 # Remove audit logs
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo find /var/log/ -iname "*.log" -exec rm -f {} \;'
 
-if [[ ${OKD_VERSION} != "none" ]]
-then
-    # Install the hyperV rpms to VM
-    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora.repo'
-    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora-updates.repo'
-    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rpm-ostree install --allow-inactive hyperv-daemons'
-    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora.repo'
-    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora-updates.repo'
-else
-    # Download the hyperV daemons dependency on host
-    mkdir $1/packages
-    sudo yum install -y --downloadonly --downloaddir $1/packages hyperv-daemons
-
-    # SCP the downloaded rpms to VM
-    ${SCP} -r $1/packages core@api.${CRC_VM_NAME}.${BASE_DOMAIN}:/home/core/
-
-    # Install the hyperV rpms to VM
-    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rpm-ostree install /home/core/packages/*.rpm'
-
-    # Remove the packages from VM
-    ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- rm -fr /home/core/packages
-
-    # Cleanup up packages
-    rm -fr $1/packages
+if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ]; then
+    prepare_hyperV "$1"
 fi
-
-# Adding Hyper-V vsock support
-
-${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} 'sudo bash -x -s' <<EOF
-    echo 'CONST{virt}=="microsoft", RUN{builtin}+="kmod load hv_sock"' > /etc/udev/rules.d/90-crc-vsock.rules
-EOF
 
 # Add gvisor-tap-vsock service
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} 'sudo bash -x -s' <<EOF

--- a/snc-library.sh
+++ b/snc-library.sh
@@ -10,6 +10,22 @@ function preflight_failure() {
         fi
 }
 
+function download_oc() {
+    mkdir -p openshift-clients/linux
+    curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/linux oc
+
+    if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then
+        mkdir -p openshift-clients/mac
+        curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-mac-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/mac oc
+    fi
+    if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ]; then
+        mkdir -p openshift-clients/windows
+        curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-windows-${OPENSHIFT_RELEASE_VERSION}.zip" > openshift-clients/windows/oc.zip
+        ${UNZIP} -o -d openshift-clients/windows/ openshift-clients/windows/oc.zip
+    fi
+}
+
+
 function run_preflight_checks() {
         echo "Checking libvirt and DNS configuration"
 

--- a/snc.sh
+++ b/snc.sh
@@ -43,12 +43,8 @@ else
     fi
 fi
 
-# Download the oc binary for all platforms
-mkdir -p openshift-clients/linux openshift-clients/mac openshift-clients/windows
-curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-linux-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/linux oc
-curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-mac-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/mac oc
-curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-windows-${OPENSHIFT_RELEASE_VERSION}.zip" > openshift-clients/windows/oc.zip
-${UNZIP} -o -d openshift-clients/windows/ openshift-clients/windows/oc.zip
+# Download the oc binary for specific OS environment
+download_oc
 OC=./openshift-clients/linux/oc
 
 run_preflight_checks

--- a/tools.sh
+++ b/tools.sh
@@ -16,12 +16,18 @@ CRC_ZSTD_EXTRA_FLAGS=${CRC_ZSTD_EXTRA_FLAGS:-"--ultra -22"}
 
 ARCH=$(uname -m)
 
-
-yq_ARCH=${ARCH}
-# yq and install_config.yaml use amd64 as arch for x86_64
-if [ "${ARCH}" == "x86_64" ]; then
-    yq_ARCH="amd64"
-fi
+case "${ARCH}" in
+    x86_64)
+        yq_ARCH="amd64"
+        SNC_GENERATE_MACOS_BUNDLE=1
+	SNC_GENERATE_WINDOWS_BUNDLE=1
+	;;
+    *)
+        yq_ARCH=${ARCH}
+        SNC_GENERATE_MACOS_BUNDLE=
+        SNC_GENERATE_WINDOWS_BUNDLE=
+	;;
+esac
 
 # Download yq/jq for manipulating in place yaml configs
 if ! "${YQ}" -V; then
@@ -55,6 +61,11 @@ if ! rpm -q libguestfs-xfs; then
     sudo yum install libguestfs-xfs
 fi
 
+if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ];then
+    if ! which ${UNZIP}; then
+        sudo yum -y install /usr/bin/unzip
+    fi
+fi
 
 if ! which ${XMLLINT}; then
     sudo yum -y install /usr/bin/xmllint
@@ -63,9 +74,7 @@ fi
 if ! which ${DIG}; then
     sudo yum -y install /usr/bin/dig
 fi
-if ! which ${UNZIP}; then
-    sudo yum -y install /usr/bin/unzip
-fi
+
 if ! which ${ZSTD}; then
     sudo yum -y install /usr/bin/zstd
 fi


### PR DESCRIPTION
On most arches, it makes no sense to generate macos and/or Windows bundles.
This commit adds SNC_GENERATE_{MACOS,WINDOWS}_BUNDLE variables which will
only be set x86_64.