### PR TITLE
Make explicit in the console that this login method is for developer

### DIFF
--- a/htpasswd_cr.yaml
+++ b/htpasswd_cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster
 spec:
   identityProviders:
-  - name: htpasswd_provider 
+  - name: developer
     mappingMethod: claim 
     type: HTPasswd
     htpasswd:


### PR DESCRIPTION
![Screenshot from 2021-02-09 20-05-18](https://user-images.githubusercontent.com/172624/107414397-3c4a0780-6b12-11eb-852c-1da239557601.png)


vs 

![Screenshot from 2021-02-09 14-33-49](https://user-images.githubusercontent.com/172624/107370891-da72a900-6ae3-11eb-9ba7-fc59be1d379b.png)


"developer" instead of htpasswd_provider