### PR TITLE
demo: modify the release image without creating a new container image

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -78,10 +78,6 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} 'sudo bash -x -s' <<EOF
   systemctl enable gvisor-tap-vsock.service
 EOF
 
-# SCP the kubeconfig file to VM
-${SCP} $1/auth/kubeconfig core@api.${CRC_VM_NAME}.${BASE_DOMAIN}:/home/core/
-${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo mv /home/core/kubeconfig /opt/'
-
 # Shutdown and Start the VM after installing the hyperV daemon packages.
 # This is required to get the latest ostree layer which have those installed packages.
 shutdown_vm ${VM_PREFIX}

--- a/custom-release.json
+++ b/custom-release.json
@@ -1,0 +1,21 @@
+[
+  {
+    "op": "add",
+    "path": "/spec/template/spec/volumes/3",
+    "value": {
+      "hostPath": {
+        "path": "/opt/release-manifests"
+      },
+      "name": "manifests"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/template/spec/containers/0/volumeMounts/3",
+    "value": {
+      "mountPath": "/release-manifests",
+      "name": "manifests",
+      "readOnly": true
+    }
+  }
+]


### PR DESCRIPTION
This exports all manifests to the VM disk, modify them, and then mount
them in the CVO pod.

---

This is an alternative to a previous experiment where I needed to upload a new release image.
This attempt is far less simple! 

/hold