### PR TITLE
Add retry for virsh commands

### DIFF
--- a/tools.sh
+++ b/tools.sh
@@ -110,7 +110,7 @@ function get_vm_prefix {
 
 function shutdown_vm {
     local vm_prefix=$1
-    sudo virsh shutdown ${vm_prefix}-master-0
+    retry sudo virsh shutdown ${vm_prefix}-master-0
     # Wait till instance started successfully
     until sudo virsh domstate ${vm_prefix}-master-0 | grep shut; do
         echo " ${vm_prefix}-master-0 still running"
@@ -120,7 +120,7 @@ function shutdown_vm {
 
 function start_vm {
     local vm_prefix=$1
-    sudo virsh start ${vm_prefix}-master-0
+    retry sudo virsh start ${vm_prefix}-master-0
     # Wait till ssh connection available
     until ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- "exit 0" >/dev/null 2>&1; do
         echo " ${vm_prefix}-master-0 still booting"


### PR DESCRIPTION
Since RHEL-8.3 now uses libvirtd.socket for service activation, on
the CI side we are observing connection timeout during virsh commands.

```
+ sudo virsh start crc-2ss7l-master-0
error: failed to connect to the hypervisor
error: Cannot recv data: Connection reset by peer
```