### PR TITLE
Ignore replica update for etcd-quorum-guard

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -190,7 +190,7 @@ retry ${OC} delete clusteroperator machine-config
 retry ${OC} scale --replicas=1 ingresscontroller/default -n openshift-ingress-operator
 
 # Scale etcd-quorum deployment from 3 to 1
-retry ${OC} scale --replicas=1 deployment etcd-quorum-guard -n openshift-etcd
+retry ${OC} scale --replicas=1 deployment etcd-quorum-guard -n openshift-etcd || true
 
 # Set default route for registry CRD from false to true.
 retry ${OC} patch config.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge


### PR DESCRIPTION
In 4.8 there is no deployment for `etcd-quorum-guard` and it is making
CI to be fail for the master branch of installer.

This can be removed as soon as we branch out 4.7 and use master for the
4.8 side.