### PR TITLE
Add a check for systemReserved key in kubelet

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -47,6 +47,12 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo podman pull quay.io/crcont
 # Stop the kubelet service so it will not reprovision the pods
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl stop kubelet
 
+# Check if system reserved block exist in kubelet config.
+# This is used to detect a buggy situation when the kubelet config file is empty and
+# we remove the systemReserved field.
+${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} cat /etc/kubernetes/kubelet.conf \
+  | ${YQ} eval -e 'has("systemReserved")' -
+
 # Remove system reserved block from kubelet config
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} cat /etc/kubernetes/kubelet.conf \
   | ${YQ} eval 'del(.systemReserved)' - \


### PR DESCRIPTION
It is Observered that in one of the CI run the kubelet.conf file
was empty but then also createdisk process didn't exit because `yq`
doesn't check the key exist during the delete.

fixes: #335