### PR TITLE
Remove auth and etcd hack

### DIFF
--- a/snc-library.sh
+++ b/snc-library.sh
@@ -110,26 +110,6 @@ function replace_pull_secret() {
         set -x
 }
 
-function apply_bootstrap_etcd_hack() {
-        # This is needed for now due to etcd changes in 4.4:
-        # https://github.com/openshift/cluster-etcd-operator/pull/279
-        while ! ${OC} get etcds cluster >/dev/null 2>&1; do
-            sleep 3
-        done
-        echo "API server is up, applying etcd hack"
-        ${OC} patch etcd cluster -p='{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableEtcd": true}}}' --type=merge
-}
-
-function apply_auth_hack() {
-        # This is needed for now due to recent change in auth:
-        # https://github.com/openshift/cluster-authentication-operator/pull/318
-        while ! ${OC} get authentications.operator.openshift.io cluster >/dev/null 2>&1; do
-            sleep 3
-        done
-        echo "Auth operator is now available, applying auth hack"
-        ${OC} patch authentications.operator.openshift.io cluster -p='{"spec": {"unsupportedConfigOverrides": {"useUnsupportedUnsafeNonHANonProductionUnstableOAuthServer": true}}}' --type=merge
-}
-
 function create_json_description {
     openshiftInstallerVersion=$(${OPENSHIFT_INSTALL} version)
     sncGitHash=$(git describe --abbrev=4 HEAD 2>/dev/null || git rev-parse --short=4 HEAD)

--- a/snc.sh
+++ b/snc.sh
@@ -151,9 +151,6 @@ OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=$OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRI
 # mask the chronyd service on the bootstrap node
 cat <<< $(${JQ} '.systemd.units += [{"mask": true, "name": "chronyd.service"}]' ${INSTALL_DIR}/bootstrap.ign) > ${INSTALL_DIR}/bootstrap.ign
 
-apply_bootstrap_etcd_hack &
-apply_auth_hack &
-
 ${OPENSHIFT_INSTALL} --dir ${INSTALL_DIR} create cluster ${OPENSHIFT_INSTALL_EXTRA_ARGS} || ${OC} adm must-gather --dest-dir ${INSTALL_DIR}
 
 if [[ ${CERT_ROTATION} == "enabled" ]]


### PR DESCRIPTION
With 4.8 we don't require any auth and etcd hack to add unsupported
onfig override, better to remove it from master branch which now
targeted with 4.8 side.

fixes: #374