### PR TITLE
Add rsync package to host machine for CI run

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -2,7 +2,7 @@
 
 set -exuo pipefail
 
-sudo yum install -y podman make golang
+sudo yum install -y podman make golang rsync
 
 cat > /tmp/ignoretests.txt << EOF
 [sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance] [Suite:openshift/conformance/serial/minimal] [Suite:k8s]

--- a/ci.sh
+++ b/ci.sh
@@ -18,7 +18,7 @@ EOF
 
 echo "### Extracting openshift-tests binary"
 mkdir /tmp/os-test
-export TESTS_IMAGE=$(oc --kubeconfig=crc-tmp-install-data/auth/kubeconfig adm release info --image-for=tests)
+export TESTS_IMAGE=$(oc --kubeconfig=crc-tmp-install-data/auth/kubeconfig adm release info -a "${HOME}"/pull-secret --image-for=tests)
 oc image extract -a "${HOME}"/pull-secret "${TESTS_IMAGE}" --path=/usr/bin/openshift-tests:/tmp/os-test/.
 chmod +x /tmp/os-test/openshift-tests
 sudo mv /tmp/os-test/openshift-tests /usr/local/bin/


### PR DESCRIPTION
`rsync` is required in case failure occur and we capture the must-gather logs.

```
[must-gather-mlqs2] OUT downloading gather output
WARNING: rsync command not found in path. Please use your package manager to install it.
[must-gather-mlqs2] OUT ./version
```

fixes: #371