### PR TITLE
Use PR number for bundle destination directory

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -7,6 +7,7 @@ function get_dest_dir {
     if [ "${OPENSHIFT_VERSION-}" != "" ]; then
         DEST_DIR=$OPENSHIFT_VERSION
     else
+        DEST_DIR=${PULL_NUMBER}
         set +e
         DEST_DIR=$(git describe --exact-match --tags HEAD)
         set -e

--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -8,9 +8,6 @@ function get_dest_dir {
         DEST_DIR=$OPENSHIFT_VERSION
     else
         DEST_DIR=${PULL_NUMBER}
-        set +e
-        DEST_DIR=$(git describe --exact-match --tags HEAD)
-        set -e
         if [ -z ${DEST_DIR} ]; then
             DEST_DIR="$(date --iso-8601)"
         fi


### PR DESCRIPTION
'PULL_NUMBER' is part of prow job env variables and can be used for
step registry in openshift CI. It will help us to have only latest bundle
for each PR.

- https://github.com/kubernetes/test-infra/blob/master/prow/jobs.md#job-environment-variables

fixes: #383