### PR TITLE
Remove luks support code

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -25,9 +25,6 @@ function sparsify {
     # https://bugzilla.redhat.com/show_bug.cgi?id=1837765
     export LIBGUESTFS_MEMSIZE=2048
     # Interact with guestfish directly
-    # Starting with 4.3, the root partition is an encryption-ready luks partition
-    # - virt-sparsify is not able to deal at all with this partition
-    # The following commands will do all of the above after mounting the luks partition
     eval $(echo nokey | ${GUESTFISH}  --keys-from-stdin --listen )
     if [ $? -ne 0 ]; then
             echo "${GUESTFISH} failed to start, aborting"
@@ -39,15 +36,7 @@ add-drive $baseDir/$srcFile
 run
 EOF
 
-    if [[ ${USE_LUKS} == "true" ]]
-    then
-        ${GUESTFISH} --remote <<EOF
-luks-open $partition coreos-root
-mount /dev/mapper/coreos-root /
-EOF
-    else
-        ${GUESTFISH} --remote mount $partition /
-    fi
+    ${GUESTFISH} --remote mount $partition /
 
     ${GUESTFISH} --remote zero-free-space /boot/
     if [ $? -ne 0 ]; then

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -10,7 +10,7 @@ source createdisk-library.sh
 
 SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
 SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
-# If the user set OKD_VERSION in the environment, then use it to override OPENSHIFT_VERSION, set BASE_OS, and set USE_LUKS
+# If the user set OKD_VERSION in the environment, then use it to override OPENSHIFT_VERSION, set BASE_OS
 # Unless, those variables are explicitly set as well.
 OKD_VERSION=${OKD_VERSION:-none}
 if [[ ${OKD_VERSION} != "none" ]]
@@ -19,7 +19,6 @@ then
     BASE_OS=fedora-coreos
 fi
 BASE_OS=${BASE_OS:-rhcos}
-USE_LUKS=${USE_LUKS:-false}
 
 # CRC_VM_NAME: short VM name to use in crc_libvirt.sh
 # BASE_DOMAIN: domain used for the cluster


### PR DESCRIPTION
Newer OpenShift version (4.7 and newer) no longer use LUKS by default.
OKD does not use it either, so we can remove this code.
This keeps the manual sparsification of the partition for now, as
virt-sparsify failed after a quick try (maybe because / is marked as
immutable?).