### PR TITLE
Remove etcd-quorum-guard deployment resource

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -189,9 +189,6 @@ retry ${OC} delete clusteroperator machine-config
 # Scale route deployment from 2 to 1
 retry ${OC} scale --replicas=1 ingresscontroller/default -n openshift-ingress-operator
 
-# Scale etcd-quorum deployment from 3 to 1
-retry ${OC} scale --replicas=1 deployment etcd-quorum-guard -n openshift-etcd || true
-
 # Set default route for registry CRD from false to true.
 retry ${OC} patch config.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
 


### PR DESCRIPTION
With 4.8 there is no etcd-quorum for single node replica and in the
CI it fails with following so better to remove it.

```
$ oc scale --replicas=1 deployment etcd-quorum-guard -n openshift-etcd
Error from server (NotFound): deployments.apps "etcd-quorum-guard" not found
```