### PR TITLE
Add PODMAN_VERSION env variable for CI

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -113,7 +113,7 @@ EOF
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rm -fr /etc/cni/net.d/100-crio-bridge.conf'
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo rm -fr /etc/cni/net.d/200-loopback.conf'
 
-podman_version=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'podman version -f json | jq -r .Client.Version')
+podman_version=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'rpm -q --qf %{version} podman')
 
 # Remove the journal logs.
 # Note: With `sudo journalctl --rotate --vacuum-time=1s`, it doesn't


### PR DESCRIPTION
Fixes #396

Master branch on the openshift/installer side uses dev version
of podman which is not available on release pages and this causes
CI failure.

```
INFO[2021-04-19T21:36:44Z] + download_podman 3.0.2-dev
INFO[2021-04-19T21:36:44Z] + local version=3.0.2-dev
INFO[2021-04-19T21:36:44Z] + mkdir -p podman-remote/linux
INFO[2021-04-19T21:36:44Z] + curl -L https://github.com/containers/podman/releases/download/v3.0.2-dev/podman-remote-static.tar.gz
INFO[2021-04-19T21:36:44Z] + tar -zx -C podman-remote/linux podman-remote-static
INFO[2021-04-19T21:36:44Z]   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
INFO[2021-04-19T21:36:44Z]                                  Dload  Upload   Total   Spent    Left  Speed
INFO[2021-04-19T21:36:44Z]
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100     9  100     9    0     0     63      0 --:--:-- --:--:-- --:--:--    64
INFO[2021-04-19T21:36:44Z]
INFO[2021-04-19T21:36:44Z] gzip: stdin: not in gzip format
INFO[2021-04-19T21:36:44Z] tar: Child returned status 1
INFO[2021-04-19T21:36:44Z] tar: Error is not recoverable: exiting now
```

This patch add `PODMAN_VERSION` variable which is set on the CI for
latest version (currently 3.1.1).