### PR TITLE
Remove machineconfigs and machineconfigspools

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -210,6 +210,10 @@ retry ${OC} replace -f pull-secret.yaml
 # Remove the Cluster ID with a empty string.
 retry ${OC} patch clusterversion version -p '{"spec":{"clusterID":""}}' --type merge
 
+# Remove machineconfigs(mc) and machineconfigpools(mcp)
+retry ${OC} delete machineconfigs --all
+retry ${OC} delete machineconfigpools --all
+
 # SCP the kubeconfig file to VM
 ${SCP} ${KUBECONFIG} core@api.${CRC_VM_NAME}.${BASE_DOMAIN}:/home/core/
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo mv /home/core/kubeconfig /opt/'


### PR DESCRIPTION
We are already override the machine config operator so removing those
configs shouldn't affect the cluster and those are regenerated with
updated content as long as user enable it.