### PR TITLE
Add security message on the web console

### DIFF
--- a/security-notice.yaml
+++ b/security-notice.yaml
@@ -1,0 +1,9 @@
+apiVersion: console.openshift.io/v1
+kind: ConsoleNotification
+metadata:
+  name: security-notice
+spec:
+  text: CodeReady Containers OpenShift cluster is for development and testing purposes. DON'T use it for production.
+  location: BannerTop
+  color: '#fff'
+  backgroundColor: darkred

--- a/snc.sh
+++ b/snc.sh
@@ -204,6 +204,9 @@ retry ${OC} create clusterrolebinding kubeadmin --clusterrole=cluster-admin --us
 # Remove temp kubeadmin user
 retry ${OC} delete secrets kubeadmin -n kube-system
 
+# Add security message on the web console
+retry ${OC} create -f security-notice.yaml
+
 # Replace pull secret with a null json string '{}'
 retry ${OC} replace -f pull-secret.yaml
 


### PR DESCRIPTION
Display a banner on top of the console saying this cluster is not for
production usage.

![Screenshot from 2021-05-03 09-37-15](https://user-images.githubusercontent.com/172624/116851708-30428300-abf3-11eb-9589-3c6edd01dfde.png)
