### PR TITLE
Add a tip in login page for getting credentials

### DIFF
--- a/login.html.patch
+++ b/login.html.patch
@@ -1,0 +1,26 @@
+--- login.html.reference	2021-05-03 10:05:31.067489685 +0200
++++ login.html	2021-05-03 10:05:43.947556555 +0200
+@@ -253,6 +253,14 @@
+               <input type="hidden" name="{{ .Names.Then }}" value="{{ .Values.Then }}">
+               <input type="hidden" name="{{ .Names.CSRF }}" value="{{ .Values.CSRF }}">
+               <div class="error-placeholder">
++                <p class="pf-c-form__helper-text">
++                  <svg style="vertical-align:-0.125em" fill="currentColor" height="1em" width="1em" viewBox="0 0 512 512" aria-hidden="true" role="img" class="pf-m-error__icon">
++                    <path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zM262.655 90c-54.497 0-89.255 22.957-116.549 63.758-3.536 5.286-2.353 12.415 2.715 16.258l34.699 26.31c5.205 3.947 12.621 3.008 16.665-2.122 17.864-22.658 30.113-35.797 57.303-35.797 20.429 0 45.698 13.148 45.698 32.958 0 14.976-12.363 22.667-32.534 33.976C247.128 238.528 216 254.941 216 296v4c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12v-1.333c0-28.462 83.186-29.647 83.186-106.667 0-58.002-60.165-102-116.531-102zM256 338c-25.365 0-46 20.635-46 46 0 25.364 20.635 46 46 46s46-20.636 46-46c0-25.365-20.635-46-46-46z"></path>
++                  </svg>
++                  Open a terminal and run 'crc console --credentials' to get your credentials.
++                </p>
++              </div>
++              <div class="error-placeholder">
+                 {{ if .Error }}
+                 <p class="pf-c-form__helper-text pf-m-error">
+                   <svg style="vertical-align:-0.125em" fill="currentColor" height="1em" width="1em" viewBox="0 0 512 512" aria-hidden="true" role="img" class="pf-m-error__icon">
+@@ -267,7 +275,7 @@
+                   <span class="pf-c-form__label-text">Username</span>
+                   <span class="pf-c-form__label-required" aria-hidden="true">*</span>
+                 </label>
+-                <input type="text" class="pf-c-form-control" id="inputUsername" placeholder="" tabindex="1" autofocus="autofocus" type="text" name="{{ .Names.Username }}" value="{{ .Values.Username }}">
++                <input type="text" class="pf-c-form-control" id="inputUsername" placeholder="" tabindex="1" autofocus="autofocus" type="text" name="{{ .Names.Username }}" value="{{ if .Values.Username }}{{ .Values.Username }}{{ else }}developer{{ end }}">
+               </div>
+               <div class="pf-c-form__group">
+                 <label class="pf-c-form__label" for="inputPassword">

--- a/oauth_cr.yaml
+++ b/oauth_cr.yaml
@@ -12,3 +12,6 @@ spec:
     htpasswd:
       fileData:
         name: htpass-secret 
+  templates:
+    login:
+      name: login-template

--- a/snc.sh
+++ b/snc.sh
@@ -192,6 +192,11 @@ retry ${OC} scale --replicas=1 ingresscontroller/default -n openshift-ingress-op
 # Set default route for registry CRD from false to true.
 retry ${OC} patch config.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
 
+# Add a tip in the login page
+retry ${OC} get secrets -n openshift-authentication v4-0-config-system-ocp-branding-template -o json | ${JQ} -r '.data["login.html"]'  | base64 -d > login.html
+${PATCH} login.html < login.html.patch
+retry ${OC} create secret generic login-template --from-file=login.html -n openshift-config
+
 # Generate the htpasswd file to have admin and developer user
 generate_htpasswd_file ${INSTALL_DIR} ${HTPASSWD_FILE}
 

--- a/tools.sh
+++ b/tools.sh
@@ -14,6 +14,7 @@ ZSTD=${ZSTD:-zstd}
 CRC_ZSTD_EXTRA_FLAGS=${CRC_ZSTD_EXTRA_FLAGS:-"--ultra -22"}
 
 HTPASSWD=${HTPASSWD:-htpasswd}
+PATCH=${PATCH:-patch}
 
 ARCH=$(uname -m)
 
@@ -81,6 +82,10 @@ fi
 
 if ! which ${HTPASSWD}; then
     sudo yum -y install /usr/bin/htpasswd
+fi
+
+if ! which ${PATCH}; then
+    sudo yum -y install /usr/bin/patch
 fi
 
 function retry {


### PR DESCRIPTION
When starting the cluster from the tray or when restarting a cluster
after a long time, the user might not remember the credentials.
This message will help him get into the cluster.

![Screenshot from 2021-05-03 10-12-56](https://user-images.githubusercontent.com/172624/116854568-2cfdc600-abf8-11eb-85c1-7b061a315b83.png)

(wording, is it secure, etc.. to be discussed :) !)