### PR TITLE
Remove kubeadmin-passwd file from the bundle

### DIFF
--- a/crc-bundle-info.json.sample
+++ b/crc-bundle-info.json.sample
@@ -6,7 +6,8 @@
   # Version history:
   # - 1.1: addition of 'name'
   # - 1.2: addition of 'storage.fileList'
-  "version": "1.2",
+  # - 1.3: remove of 'clusterInfo.kubeadminPasswordFile'
+  "version": "1.3",
   # Type of this bundle content
   # Currently the only valid type is 'snc' (which stands for 'single-node-cluster')
   "type": "snc",
@@ -35,9 +36,6 @@
     "sshPrivateKeyFile": "id_ecdsa_crc",
     # Name of the kubeconfig file stored in the bundle
     "kubeConfig": "kubeconfig",
-    # Name of the file containing the kubeadmin password for use in the
-    # openshift console
-    "kubeadminPasswordFile": "kubeadmin-password"
     # pull secret that can be used to fetch OpenShift container images (optional)
     # "openshiftPullSecret": "default-pull-secret"
   },

--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -99,7 +99,6 @@ function update_json_description {
         | ${JQ} ".name = \"${destDir}\"" \
         | ${JQ} '.clusterInfo.sshPrivateKeyFile = "id_ecdsa_crc"' \
         | ${JQ} '.clusterInfo.kubeConfig = "kubeconfig"' \
-        | ${JQ} '.clusterInfo.kubeadminPasswordFile = "kubeadmin-password"' \
         | ${JQ} '.nodes[0].kind[0] = "master"' \
         | ${JQ} '.nodes[0].kind[1] = "worker"' \
         | ${JQ} ".nodes[0].hostname = \"${VM_PREFIX}-master-0\"" \
@@ -138,8 +137,8 @@ function copy_additional_files {
     local srcDir=$1
     local destDir=$2
 
-    # Copy the kubeconfig and kubeadm password file
-    cp $1/auth/kube* $destDir/
+    # Copy the kubeconfig file
+    cp $1/auth/kubeconfig $destDir/
 
     # Copy the master public key
     cp id_ecdsa_crc $destDir/
@@ -195,7 +194,6 @@ function generate_hyperkit_bundle {
     local kernel_cmd_line=$5
 
     mkdir "$destDir"
-    cp $srcDir/kubeadmin-password $destDir/
     cp $srcDir/kubeconfig $destDir/
     cp $srcDir/id_ecdsa_crc $destDir/
     cp $srcDir/${CRC_VM_NAME}.qcow2 $destDir/
@@ -239,7 +237,6 @@ function generate_hyperv_bundle {
 
     mkdir "$destDir"
 
-    cp $srcDir/kubeadmin-password $destDir/
     cp $srcDir/kubeconfig $destDir/
     cp $srcDir/id_ecdsa_crc $destDir/
 

--- a/test-metadata-generation.sh
+++ b/test-metadata-generation.sh
@@ -26,7 +26,6 @@ destDir=dest
 mkdir -p "$srcDir"
 mkdir -p "$srcDir/auth"
 touch "$srcDir"/auth/kubeconfig
-touch "$srcDir"/auth/kubeadmin-password
 touch id_ecdsa_crc
 touch "$srcDir"/vmlinuz-0.0.0
 touch "$srcDir"/initramfs-0.0.0.img


### PR DESCRIPTION
Since new `kubeadmin` user is created using `htpasswd` provider and
password is updated for each time when `crc start` happen.

fixes: #414