### PR TITLE
Remove old rendered master/worker machine config

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -241,3 +241,8 @@ wait_till_cluster_stable
 
 # Delete the pods which are there in Complete state
 retry ${OC} delete pod --field-selector=status.phase==Succeeded --all-namespaces
+
+# Delete outdated rendered master/worker machineconfigs and just keep the latest one
+${OC} get mc --sort-by=.metadata.creationTimestamp --no-headers -oname | grep rendered-master | head -n -1 | xargs -t ${OC} delete
+${OC} get mc --sort-by=.metadata.creationTimestamp --no-headers -oname | grep rendered-worker | head -n -1 | xargs -t ${OC} delete
+


### PR DESCRIPTION
Those old rendered machine config contain the initial pull spec for
the cluster so better to remove those and only keep latest one.

```
$ oc get mc --sort-by=.metadata.creationTimestamp --no-headers
99-master-ssh                                                                                 3.2.0   43h
chronyd-mask                                                                                  3.1.0   43h
99-worker-ssh                                                                                 3.2.0   43h
99-openshift-machineconfig-master-dummy-networks                                              3.2.0   43h
00-master                                          b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
00-worker                                          b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
01-master-kubelet                                  b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
01-master-container-runtime                        b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
01-worker-container-runtime                        b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
01-worker-kubelet                                  b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
rendered-master-6a52c924beeab10c4d917eb7786d8d9c   b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
rendered-worker-c0d4ccd0599554ca84cdac121c99b8c0   b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
99-worker-generated-registries                     b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
99-master-generated-registries                     b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   43h
rendered-worker-73ad21005c178f63a66398638aaa05ae   b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   18h
rendered-master-35111bcd08dccd57f47acaa57cb1d296   b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   18h
rendered-master-f5f05aad7d6a34e21fca04e799e54a44   b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   3h21m
rendered-worker-24d71aa1fbe25a89567669d89d53065d   b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   3h21m
rendered-master-de3a028583cb2ac28121fc8d527637a2   b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   142m
rendered-worker-68ca5066a7c81354e3693a0abf8ff3df   b20ecdcd81dc3aa1269757ddfe97603918194b3b   3.2.0   142m

// All the rendered master except lastet one
$ oc get mc --sort-by=.metadata.creationTimestamp --no-headers -oname | grep rendered-master | head -n -1
machineconfig.machineconfiguration.openshift.io/rendered-master-6a52c924beeab10c4d917eb7786d8d9c
machineconfig.machineconfiguration.openshift.io/rendered-master-35111bcd08dccd57f47acaa57cb1d296
machineconfig.machineconfiguration.openshift.io/rendered-master-f5f05aad7d6a34e21fca04e799e54a44
```