### PR TITLE
Force kill any existing dnf process

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -2,6 +2,7 @@
 
 set -exuo pipefail
 
+sudo pkill -9 dnf
 sudo yum install -y podman make golang rsync
 
 cat > /tmp/ignoretests.txt << EOF


### PR DESCRIPTION
We are seeing lot of failure on the CI because of existing
dnf process.

```
+ sudo yum install -y podman make golang rsync
[...]
Waiting for process with pid 1281 to finish.
```