### PR TITLE
Revert "Force kill any existing dnf process"

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -2,7 +2,6 @@
 
 set -exuo pipefail
 
-sudo pkill -9 dnf
 sudo yum install -y podman make golang rsync
 
 cat > /tmp/ignoretests.txt << EOF


### PR DESCRIPTION
This reverts commit 0b1f211314770d4f8206351609a455125fc531ec.

With https://github.com/ironcladlou/openshift4-libvirt-gcp/pull/43
merged, this is no longer needed, and even causes failures when pkill
does not any processes to kill.