### PR TITLE
Disable the chronyd service instead masking it

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -46,11 +46,6 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo podman pull quay.io/crcont
 # Stop the kubelet service so it will not reprovision the pods
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl stop kubelet
 
-# Unmask the chronyd service
-${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl unmask chronyd
-# Disable the chronyd service
-${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl disable chronyd
-
 # Enable the podman.socket service for API V2
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl enable podman.socket
 

--- a/snc.sh
+++ b/snc.sh
@@ -220,9 +220,6 @@ retry ${OC} delete secrets kubeadmin -n kube-system
 # Add security message on the web console
 retry ${OC} create -f security-notice.yaml
 
-# Replace pull secret with a null json string '{}'
-retry ${OC} replace -f pull-secret.yaml
-
 # Remove the Cluster ID with a empty string.
 retry ${OC} patch clusterversion version -p '{"spec":{"clusterID":""}}' --type merge
 
@@ -251,6 +248,12 @@ retry ${OC} patch image.config.openshift.io cluster -p '{"spec": {"additionalTru
 retry ${OC} delete mc chronyd-mask
 
 # Wait for the cluster again to become stable because of all the patches/changes
+wait_till_cluster_stable
+
+# Replace pull secret with a null json string '{}'
+retry ${OC} replace -f pull-secret.yaml
+
+# Wait for the cluster again to become stable because of remove of pull secret
 wait_till_cluster_stable
 
 # Delete the pods which are there in Complete state

--- a/snc.sh
+++ b/snc.sh
@@ -247,6 +247,9 @@ retry ${OC} extract secret/router-ca --keys=tls.crt -n openshift-ingress-operato
 retry ${OC} create configmap registry-certs --from-file=default-route-openshift-image-registry.apps-crc.testing=tls.crt -n openshift-config
 retry ${OC} patch image.config.openshift.io cluster -p '{"spec": {"additionalTrustedCA": {"name": "registry-certs"}}}' --type merge
 
+# Remove the machine config for chronyd to make it active again
+retry ${OC} delete mc chronyd-mask
+
 # Wait for the cluster again to become stable because of all the patches/changes
 wait_till_cluster_stable
 


### PR DESCRIPTION
As of now, we are unmasking the chronyd unit file directly using
ssh command so in case of MCO enabled it modify it back again to
masked one so first start of bundle succeed but it fails as soon
as we do stop => start since the crc codebase not able to start
a masked unit.

```
$ systemctl status chronyd.service
● chronyd.service
   Loaded: masked (Reason: Unit chronyd.service is masked.)
   Active: inactive (dead)
$ sudo timedatectl set-ntp on
Failed to set ntp: Failed to start/stop NTP unit
```