### PR TITLE
Don't disable the chronyd service

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -59,8 +59,6 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} cat /etc/kubernetes/kubelet.conf \
 
 # Unmask the chronyd service
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl unmask chronyd
-# Disable the chronyd service
-${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl disable chronyd
 
 # Enable the podman.socket service for API V2
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl enable podman.socket


### PR DESCRIPTION
This patch will make sure the generated bundle have same kind of
property for 4.8 (0beeb25) and 4.7 which is running chronyd service
as default.