### PR TITLE
Remove the system:openshift:openshift-authenticator csr

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -169,6 +169,10 @@ fi
 # Wait for install to complete, this provide another 30 mins to make resources (apis) stable
 ${OPENSHIFT_INSTALL} --dir ${INSTALL_DIR} wait-for install-complete ${OPENSHIFT_INSTALL_EXTRA_ARGS}
 
+# Remove the openshift-authenticator CSR to force a certificate regeneration
+# BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1978193
+retry ${OC} delete csr system:openshift:openshift-authenticator
+
 # Set the VM static hostname to crc-xxxxx-master-0 instead of localhost.localdomain
 HOSTNAME=$(${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} hostnamectl status --transient)
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} sudo hostnamectl set-hostname ${HOSTNAME}


### PR DESCRIPTION
Looks like after the cert rotation
`system:openshift:openshift-authenticator` csr is not recreated and
causing issue for auth operator. As a workaround we need to manually
delete it so new csr is generated with updated cert info.

- https://bugzilla.redhat.com/show_bug.cgi?id=1978193