### PR TITLE
Add retry for pv creation commands

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -47,7 +47,7 @@ sudo mv out/linux-amd64/crc /usr/local/bin/
 popd
 
 crc setup
-crc start -p "${HOME}"/pull-secret -b crc_libvirt_*.crcbundle
+crc start --disk-size 80 -m 24000 -c 10 -p "${HOME}"/pull-secret -b crc_libvirt_*.crcbundle
 
 mkdir -p /tmp/artifacts
 export KUBECONFIG="${HOME}"/.crc/machines/crc/kubeconfig

--- a/ci.sh
+++ b/ci.sh
@@ -11,6 +11,11 @@ cat > /tmp/ignoretests.txt << EOF
 [sig-scheduling] SchedulerPreemption [Serial] validates lower priority pod preemption by critical pod [Conformance] [Suite:openshift/conformance/serial/minimal] [Suite:k8s]
 [k8s.io] [sig-node] NoExecuteTaintManager Multiple Pods [Serial] evicts pods with minTolerationSeconds [Disruptive] [Conformance] [Suite:k8s]
 [k8s.io] [sig-node] NoExecuteTaintManager Single Pod [Serial] removing taint cancels eviction [Disruptive] [Conformance] [Suite:k8s]
+[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should mutate custom resource with pruning [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]
+[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should mutate pod and apply defaults after mutation [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]
+[sig-api-machinery] Aggregator Should be able to support the 1.17 Sample API Server using the current Aggregator [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]
+[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance] [Skipped:SingleReplicaTopology] [Suite:openshift/conformance/serial/minimal] [Suite:k8s]
+[sig-network] Proxy version v1 A set of valid responses are returned for both pod and service ProxyWithPath [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]
 EOF
 
 ./shellcheck.sh

--- a/cvo-overrides-after-first-run.yaml
+++ b/cvo-overrides-after-first-run.yaml
@@ -93,3 +93,14 @@
     name: etcd-quorum-guard
     namespace: openshift-etcd
     unmanaged: true
+  - kind: Deployment
+    group: apps/v1
+    name: cluster-cloud-controller-manager-operator
+    namespace: openshift-cloud-controller-manager-operator
+    unmanaged: true
+  - kind: ClusterOperator
+    group: config.openshift.io/v1
+    name: cloud-controller-manager
+    namespace: ""
+    unmanaged: true
+

--- a/cvo-overrides.yaml
+++ b/cvo-overrides.yaml
@@ -80,3 +80,13 @@ spec:
     name: csi-snapshot-controller
     namespace: ""
     unmanaged: true
+  - kind: Deployment
+    group: apps/v1
+    name: cluster-cloud-controller-manager-operator
+    namespace: openshift-cloud-controller-manager-operator
+    unmanaged: true
+  - kind: ClusterOperator
+    group: config.openshift.io/v1
+    name: cloud-controller-manager
+    namespace: ""
+    unmanaged: true

--- a/snc.sh
+++ b/snc.sh
@@ -191,7 +191,8 @@ retry ${OC} scale --replicas=1 ingresscontroller/default -n openshift-ingress-op
 retry ${OC} patch config.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
 
 # Add a tip in the login page
-retry ${OC} get secrets -n openshift-authentication v4-0-config-system-ocp-branding-template -o json | ${JQ} -r '.data["login.html"]'  | base64 -d > login.html
+secret_template=$(retry ${OC} get secrets -n openshift-authentication v4-0-config-system-ocp-branding-template -o json)
+${JQ} -r '.data["login.html"]' <(echo "${secret_template}") | base64 -d > login.html
 ${PATCH} login.html < login.html.patch
 retry ${OC} create secret generic login-template --from-file=login.html -n openshift-config
 

--- a/tools.sh
+++ b/tools.sh
@@ -96,10 +96,10 @@ function retry {
         wait=$((2 ** $count))
         count=$(($count + 1))
         if [ $count -lt $retries ]; then
-            echo "Retry $count/$retries exited $exit, retrying in $wait seconds..."
+            echo "Retry $count/$retries exited $exit, retrying in $wait seconds..." 1>&2
             sleep $wait
         else
-            echo "Retry $count/$retries exited $exit, no more retries left."
+            echo "Retry $count/$retries exited $exit, no more retries left." 1>&2
             return $exit
         fi
     done


### PR DESCRIPTION
This patch will fix following error from CI
```
./openshift-clients/linux/oc create -f -
error: error when creating "STDIN": Post "https://api.crc.testing:6443/api/v1/persistentvolumes?fieldManager=kubectl-create": dial tcp 192.168.126.11:6443: connect: connection refused
```