### PR TITLE
Compare machine config before and after apply pull secret

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -294,11 +294,13 @@ function download_podman() {
       mkdir -p podman-remote/mac
       curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-release-darwin.zip -o podman-remote/mac/podman.zip
       ${UNZIP} -o -d podman-remote/mac/ podman-remote/mac/podman.zip
+      mv podman-remote/mac/podman-${version}/podman  podman-remote/mac
     fi
 
     if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ]; then
       mkdir -p podman-remote/windows
       curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-release-windows.zip -o podman-remote/windows/podman.zip
       ${UNZIP} -o -d podman-remote/windows/ podman-remote/windows/podman.zip
+      mv podman-remote/windows/podman-${version}/podman.exe  podman-remote/windows
     fi
 }

--- a/snc-library.sh
+++ b/snc-library.sh
@@ -267,7 +267,7 @@ function wait_till_cluster_stable() {
     local count=0
 
     # Remove all the failed Pods
-    ${OC} delete pods --field-selector=status.phase=Failed -A || true
+    retry ${OC} delete pods --field-selector=status.phase=Failed -A
 
     local a=0
     while [ $a -lt $retryCount ]; do

--- a/snc-library.sh
+++ b/snc-library.sh
@@ -256,7 +256,8 @@ function no_operators_degraded() {
 }
 
 function all_pods_are_running_completed() {
-    ! ${OC} get pod --no-headers --all-namespaces | grep -v Running | grep -v Completed
+    local ignoreNamespace=$1
+    ! ${OC} get pod --no-headers --all-namespaces --field-selector=metadata.namespace!="${ignoreNamespace}" | grep -v Running | grep -v Completed
 }
 
 function wait_till_cluster_stable() {
@@ -265,6 +266,7 @@ function wait_till_cluster_stable() {
     local retryCount=30
     local numConsecutive=3
     local count=0
+    local ignoreNamespace=${1:-"none"}
 
     # Remove all the failed Pods
     retry ${OC} delete pods --field-selector=status.phase=Failed -A
@@ -287,6 +289,6 @@ function wait_till_cluster_stable() {
     done
 
     # Wait till all the pods are either running or complete state
-    retry all_pods_are_running_completed
+    retry all_pods_are_running_completed "${ignoreNamespace}"
 }
 

--- a/snc-library.sh
+++ b/snc-library.sh
@@ -255,6 +255,10 @@ function no_operators_degraded() {
     ${OC} get co -ojsonpath='{.items[*].status.conditions[?(@.type=="Degraded")].status}' | grep -v True
 }
 
+function all_pods_are_running_completed() {
+    ! ${OC} get pod --no-headers --all-namespaces | grep -v Running | grep -v Completed
+}
+
 function wait_till_cluster_stable() {
     sleep 1m
 
@@ -283,8 +287,6 @@ function wait_till_cluster_stable() {
     done
 
     # Wait till all the pods are either running or complete state
-    while ${OC} get pod --no-headers --all-namespaces | grep -v Running | grep -v Completed; do
-       sleep 2
-    done
+    retry all_pods_are_running_completed
 }
 

--- a/snc.sh
+++ b/snc.sh
@@ -249,6 +249,8 @@ while [ "${mc_before_removing_pullsecret}" == "${mc_after_removing_pullsecret}" 
 	mc_after_removing_pullsecret=$(retry ${OC} get mc --sort-by=.metadata.creationTimestamp --no-headers -oname)
 done
 
+wait_till_cluster_stable openshift-marketplace
+
 # Delete the pods which are there in Complete state
 retry ${OC} delete pod --field-selector=status.phase==Succeeded --all-namespaces
 


### PR DESCRIPTION
In current sceario when we wait for cluster to stable after removing
the pull secret then imagepull error happen for all the marketplace
images since it require the valid pull secret.

```
+ ./openshift-clients/linux/oc get pod --no-headers --all-namespaces
+ grep -v Running
+ grep -v Completed
openshift-marketplace                        certified-operators-n4vlj                                0/1   ImagePullBackOff   0     112m
openshift-marketplace                        community-operators-h5s2d                                0/1   ImagePullBackOff   0     113m
openshift-marketplace                        redhat-marketplace-rm9lm                                 0/1   ImagePullBackOff   0     112m
openshift-marketplace                        redhat-operators-9tqpf                                   0/1   ImagePullBackOff   0     113m
```

This patch will just make sure to wait till machine config render
properly.