### PR TITLE
Use podman-<version> dir to copy podman executable

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -294,11 +294,13 @@ function download_podman() {
       mkdir -p podman-remote/mac
       curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-release-darwin.zip -o podman-remote/mac/podman.zip
       ${UNZIP} -o -d podman-remote/mac/ podman-remote/mac/podman.zip
+      mv podman-remote/mac/podman-${version}/podman  podman-remote/mac
     fi
 
     if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ]; then
       mkdir -p podman-remote/windows
       curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-release-windows.zip -o podman-remote/windows/podman.zip
       ${UNZIP} -o -d podman-remote/windows/ podman-remote/windows/podman.zip
+      mv podman-remote/windows/podman-${version}/podman.exe  podman-remote/windows
     fi
 }


### PR DESCRIPTION
This should fix
```
+ unzip -o -d podman-remote/mac/ podman-remote/mac/podman.zip
Archive:  podman-remote/mac/podman.zip
   creating: podman-remote/mac/podman-3.2.3/

+ cp podman-remote/mac/podman crc_hyperkit_461/
cp: cannot stat 'podman-remote/mac/podman': No such file or directory
```