### PR TITLE
Revert "Move podman binary from podman-<version> dir to top level dir"

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -294,13 +294,11 @@ function download_podman() {
       mkdir -p podman-remote/mac
       curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-release-darwin.zip -o podman-remote/mac/podman.zip
       ${UNZIP} -o -d podman-remote/mac/ podman-remote/mac/podman.zip
-      mv podman-remote/mac/podman-${version}/podman  podman-remote/mac
     fi
 
     if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ]; then
       mkdir -p podman-remote/windows
       curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-release-windows.zip -o podman-remote/windows/podman.zip
       ${UNZIP} -o -d podman-remote/windows/ podman-remote/windows/podman.zip
-      mv podman-remote/windows/podman-${version}/podman.exe  podman-remote/windows
     fi
 }


### PR DESCRIPTION
This reverts commit fe98dd0a449800284484e4b9cdcd2c1776978d50.

4.8.5 is still shipping podman 3.0.1, this move is not needed for the
moment.

Without this, it triggers the following error:
```
+ mv podman-remote/mac/podman-3.0.1/podman podman-remote/mac
mv: cannot stat 'podman-remote/mac/podman-3.0.1/podman': No such file or directory
```