### PR TITLE
Fix typo in podman-remote directory

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -296,7 +296,7 @@ function download_podman() {
       curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-release-darwin.zip -o podman-remote/mac/podman.zip
       ${UNZIP} -o -d podman-remote/mac/ podman-remote/mac/podman.zip
       mv podman-remote/mac/podman-${version}/podman  podman-remote/mac
-      chmod +x podman/mac/podman
+      chmod +x podman-remote/mac/podman
     fi
 
     if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ]; then


### PR DESCRIPTION
This introduced during 9f73c699f9f53aa26116c19b6713a015ab550fe1 commit