### PR TITLE
Add dummy crio-wipe.service

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -66,6 +66,8 @@ ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} 'sudo bash -x -s' <<EOF
   systemctl enable gvisor-tap-vsock.service
 EOF
 
+sudo ${SCP} crio-wipe.service /etc/systemd/system/
+
 # Preload routes controller
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo crictl pull quay.io/crcont/routes-controller:latest'
 

--- a/crio-wipe.service
+++ b/crio-wipe.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Dummy crio-wipe service
+Before=crio.service
+RequiresMountsFor=/var/lib/containers
+
+[Service]
+ExecStart=/bin/true
+Type=oneshot
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
crio installs a crio-wipe.service which will wipe out
/var/lib/containers if it detects an unclean shutdown. With crc, it's can
happen quit easily when using `crc stop -f`, or if the host computer is
rebooted without shutting down the VM first. Removing /var/lib/containers
deletes all container images and containers from the VM.

For crc this is problematic, as snc creates 2 containers which are required
for a successful `crc start`. Without gvisor-tap-vsock, the VM won't even
have network access, so crc can't pull the removed images from the network,
and recreate the missing containers.

This commit works around this problem by replacing crio-wipe.service with a
dummy service which runs `/bin/true` instead of `crio wipe`. Several units,
including kubelet.service require crio-wipe.service, so we can't easily
mask it.

The worse that can happen is that the container storage was corrupted 
during the forced shutdown. If this happens, the VM will need to be 
recreated, which is no worse than the current situation, where the VM 
always has to be recreated after a forced shutdown.

This should fix https://github.com/code-ready/crc/issues/2791