### PR TITLE
Use virsh command to get internal IP instead dig

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -37,7 +37,7 @@ VM_PREFIX=$(get_vm_prefix ${CRC_VM_NAME})
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo crictl rmi --prune'
 
 # Get the IP of the VM
-INTERNAL_IP=$(${DIG} +short api.${CRC_VM_NAME}.${BASE_DOMAIN})
+INTERNAL_IP=$(sudo virsh domifaddr ${VM_PREFIX}-master-0 | tail -2 | head -1 | awk '{print $4}' | cut -d/ -f1)
 
 # Disable kubelet service
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- sudo systemctl disable kubelet


### PR DESCRIPTION
With latest changes in libvirt provider the dns is part of network
which is created by installer and the following entry is present.
```
...
$ virsh net-dumpxml crc-crzxj
  <dns enable='yes'>
    <host ip='192.168.126.10'>
      <hostname>api.crc.testing</hostname>
      <hostname>api-int.crc.testing</hostname>
    </host>
    <host ip='192.168.126.11'>
      <hostname>api.crc.testing</hostname>
      <hostname>api-int.crc.testing</hostname>
    </host>
  </dns>
...
```
So now with dig command output the both the IP when query the
`api.crc.testing`

```
$ dig +short api.crc.testing
192.168.126.11
192.168.126.10
```
This lead to corrupt the crc bundle metadata and `crc start` fails
with this.

This patch make sure it will only use the IP of master node using
virsh command.
```
$ virsh domifaddr crc-crzxj-master-0|tail -2|head -1|awk '{print $4}'| cut -d/ -f1
192.168.126.11
```