### PR TITLE
enable podman remote rootless socket

### DIFF
--- a/fcos-config.yaml
+++ b/fcos-config.yaml
@@ -9,3 +9,15 @@ systemd:
   units:
    - name: podman.socket
      enabled: true
+storage:
+  links:
+    - path: /home/core/.config/systemd/user/default.target.wants/podman.socket
+      user:
+        name: core
+      group:
+        name: core
+      target: /usr/lib/systemd/user/podman.socket
+      hard: false
+  files:
+    - path: /var/lib/systemd/linger/core
+      mode: 0644


### PR DESCRIPTION
user services can't be directly enabled in Butane configs and has
to be manually enabled

ref: https://docs.fedoraproject.org/en-US/fedora-coreos/tutorial-user-systemd-unit-on-boot/