### PR TITLE
Update qcow2 image permission from 0600 to 0644

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -63,6 +63,9 @@ function create_qemu_image {
         exit 1;
     fi
 
+    # Update the qcow2 image permission from 0600 to 0644
+    chmod 0644 ${destDir}/${CRC_VM_NAME}.qcow2
+
     rm -fr $destDir/fedora-coreos-qemu.x86_64.qcow2
 }
 


### PR DESCRIPTION
Looks like without this patch when it is used with crc on linux
then after first start the permission on the qcow2 file changes
to following.
```
$ ls -Zl ~/.crc/cache/crc_podman_libvirt_3.4.1/
total 1741452
-rw-rw-r--. 1 prkumar prkumar unconfined_u:object_r:user_home_t:s0        993 Nov 12 11:55 crc-bundle-info.json
-rw-------. 1 qemu    qemu    system_u:object_r:virt_content_t:s0  1748369408 Nov 12 11:55 crc-podman.qcow2
-r--------. 1 prkumar prkumar unconfined_u:object_r:user_home_t:s0        724 Nov 12 11:55 id_ecdsa_crc
-rwxr-xr-x. 1 prkumar prkumar unconfined_u:object_r:user_home_t:s0   34867234 Nov 12 11:55 podman-remote

$ ./crc start -b ~/Downloads/crc_podman_libvirt_3.4.1.crcbundle
[...]
INFO Creating CodeReady Containers VM for Podman 3.4.1...
Error creating machine: Error in driver during machine creation: open /home/prkumar/.crc/cache/crc_podman_libvirt_3.4.1/crc-podman.qcow2: permission denied
```

But on our openshift images it have permission `0644` so changes same
here.