### PR TITLE
Fix disk size to 31G from 10G

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -56,7 +56,7 @@ create_json_description
 sudo ${VIRT_INSTALL} --name=${CRC_VM_NAME} --vcpus=2 --ram=2048 \
 	--import --network=bridge=virbr0 --graphics=none \
 	--qemu-commandline="-fw_cfg name=opt/com.coreos/config,file=${PWD}/${CRC_INSTALL_DIR}/fcos-config.ign" \
-	--disk=size=10,backing_store=${PWD}/${CRC_INSTALL_DIR}/fedora-coreos-qemu.x86_64.qcow2 \
+	--disk=size=31,backing_store=${PWD}/${CRC_INSTALL_DIR}/fedora-coreos-qemu.x86_64.qcow2 \
 	--os-variant=fedora-coreos-stable \
 	--noautoconsole --quiet
 sleep 120


### PR DESCRIPTION
By default on the crc side we have default disk size is 31G and for
podman bundle disk resize always run which should be avoided. This
patch will increase it to default size.

If bundle size increase because of this patch then we make the change
in crc side.

- https://github.com/code-ready/crc/issues/2862