### PR TITLE
Drop version from 'group' from cvo override

### DIFF
--- a/cvo-overrides-after-first-run.yaml
+++ b/cvo-overrides-after-first-run.yaml
@@ -2,104 +2,104 @@
   path: /spec/overrides
   value:
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: cluster-monitoring-operator
     namespace: openshift-monitoring
     unmanaged: true
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: monitoring
     namespace: ""
     unmanaged: true
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: kube-storage-version-migrator-operator
     namespace: openshift-kube-storage-version-migrator-operator
     unmanaged: true
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: kube-storage-version-migrator
     namespace: ""
     unmanaged: true
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: insights-operator
     namespace: openshift-insights
     unmanaged: true
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: insights
     namespace: ""
     unmanaged: true
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: cloud-credential-operator
     namespace: openshift-cloud-credential-operator
     unmanaged: true
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: cloud-credential
     namespace: ""
     unmanaged: true
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: cluster-storage-operator
     namespace: openshift-cluster-storage-operator
     unmanaged: true
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: storage
     namespace: ""
     unmanaged: true
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: cluster-baremetal-operator
     namespace: openshift-machine-api
     unmanaged: true
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: baremetal
     namespace: ""
     unmanaged: true
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: cluster-autoscaler-operator
     namespace: openshift-machine-api
     unmanaged: true
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: cluster-autoscaler
     namespace: ""
     unmanaged: true
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: csi-snapshot-controller-operator
     namespace: openshift-cluster-storage-operator
     unmanaged: true
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: csi-snapshot-controller
     namespace: ""
     unmanaged: true
   # only used in bootstrap phase
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: machine-api
     namespace: ""
     unmanaged: true
   # required to scale down etcd-quorum-guard
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: etcd-quorum-guard
     namespace: openshift-etcd
     unmanaged: true
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: cluster-cloud-controller-manager-operator
     namespace: openshift-cloud-controller-manager-operator
     unmanaged: true
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: cloud-controller-manager
     namespace: ""
     unmanaged: true

--- a/cvo-overrides.yaml
+++ b/cvo-overrides.yaml
@@ -1,92 +1,92 @@
 spec:
   overrides:
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: cluster-monitoring-operator
     namespace: openshift-monitoring
     unmanaged: true
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: monitoring
     namespace: ""
     unmanaged: true
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: kube-storage-version-migrator-operator
     namespace: openshift-kube-storage-version-migrator-operator
     unmanaged: true
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: kube-storage-version-migrator
     namespace: ""
     unmanaged: true
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: insights-operator
     namespace: openshift-insights
     unmanaged: true
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: insights
     namespace: ""
     unmanaged: true
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: cloud-credential-operator
     namespace: openshift-cloud-credential-operator
     unmanaged: true
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: cloud-credential
     namespace: ""
     unmanaged: true
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: cluster-storage-operator
     namespace: openshift-cluster-storage-operator
     unmanaged: true
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: storage
     namespace: ""
     unmanaged: true
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: cluster-baremetal-operator
     namespace: openshift-machine-api
     unmanaged: true
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: baremetal
     namespace: ""
     unmanaged: true
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: cluster-autoscaler-operator
     namespace: openshift-machine-api
     unmanaged: true
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: cluster-autoscaler
     namespace: ""
     unmanaged: true
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: csi-snapshot-controller-operator
     namespace: openshift-cluster-storage-operator
     unmanaged: true
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: csi-snapshot-controller
     namespace: ""
     unmanaged: true
   - kind: Deployment
-    group: apps/v1
+    group: apps
     name: cluster-cloud-controller-manager-operator
     namespace: openshift-cloud-controller-manager-operator
     unmanaged: true
   - kind: ClusterOperator
-    group: config.openshift.io/v1
+    group: config.openshift.io
     name: cloud-controller-manager
     namespace: ""
     unmanaged: true


### PR DESCRIPTION
Now that the CVO looks at the group property validation and for group
it is different than apiVersion property which required the version
info. This patch drop the version info as part of group.

- https://github.com/openshift/enhancements/pull/982
- https://github.com/openshift/cluster-version-operator/pull/689