### PR TITLE
Add dispatcher script for tap device for network manager

### DIFF
--- a/fcos-config.yaml
+++ b/fcos-config.yaml
@@ -91,3 +91,16 @@ storage:
         inline: |
           [engine]
           machine_enabled=true
+    - path: /etc/NetworkManager/dispatcher.d/pre-up.d/gvisor-tap-vsock-tap-device.sh
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/sh
+
+          if [[ "$1" != "tap0" ]]; then
+              exit 0
+          fi
+          if [[ "$2" != "pre-up" ]]; then
+              exit 0
+          fi
+          nmcli device modify "$1" ipv4.method auto


### PR DESCRIPTION
In case of user mode networking, vm deployed on windows and linux
have tap interface created which used for packets to send to vsock.
For podman bundles which are based on fedora 35, looks like the dns
server is not set to the tap device and all the query fails because
of it. Also on the f35 coreos image, /etc/resolv.conf is symlinked to
/run/systemd/resolve/stub-resolv.conf, and vm binary shouldn't suppose
to directly modify it.

For a normal interface, what happens is that NetworkManager takes care
of running dhcp requests, and as part of the dhcp request, it receives
DNS details. It's then NetworkManager which takes care of forwarding
this information to systemd-resolved. With current vm binary it runs the
dhcp client.

Follow-up work would be to drop
https://github.com/containers/gvisor-tap-vsock/blob/3ec335bea2e933a377b4da70d33fb81c63fc07f5/cmd/vm/main_linux.go#L132-L144
from gvisor-tap-vsock, or to replace this by the invocation of an external
script, and to figure out how to integrate it better with NetworkManager.

In crc vm
```
$ ping gandi.net
ping: gandi.net: Name or service not known

$ sudo nmcli device modify tap0 ipv4.method auto
Connection successfully reapplied to device 'tap0'.

$ ping gandi.net
PING gandi.net (217.70.185.65) 56(84) bytes of data.
64 bytes from 217.70.185.65 (217.70.185.65): icmp_seq=1 ttl=64 time=0.245 ms
```

More discussion: https://github.com/code-ready/crc/pull/2882#discussion_r769709157