### PR TITLE
Mask zincati.service for autoupdate

### DIFF
--- a/fcos-config.yaml
+++ b/fcos-config.yaml
@@ -9,6 +9,8 @@ systemd:
   units:
    - name: podman.socket
      enabled: true
+   - name: zincati.service
+     mask: true
 storage:
   # Ignition has a bug/feature? where if you make a series of dirs
   # in one swoop, then the leading dirs are creates as root.


### PR DESCRIPTION
By default zincati service is running which responsible for auto update
of the FCOS host and it always polling the Cincinnati server, this patch
will disable it and rpm-ostree will look like following:
```
$ rpm-ostree status
State: idle
AutomaticUpdatesDriver: Zincati
  DriverState: inactive
Deployments:
[...]
```

fixes: #498