### PR TITLE
Increase timeout to 500sec from 300sec for csr approval check

### DIFF
--- a/snc-library.sh
+++ b/snc-library.sh
@@ -201,7 +201,7 @@ function renew_certificates() {
     start_vm ${vm_prefix}
 
     # After cluster starts kube-apiserver-client-kubelet signer need to be approved
-    timeout 300 bash -c -- "until ${OC} get csr | grep Pending; do echo 'Waiting for first CSR request.'; sleep 2; done"
+    timeout 500 bash -c -- "until ${OC} get csr | grep Pending; do echo 'Waiting for first CSR request.'; sleep 2; done"
     ${OC} get csr -ojsonpath='{.items[*].metadata.name}' | xargs ${OC} adm certificate approve
 
     # Retry 5 times to make sure kubelet certs are rotated correctly.


### PR DESCRIPTION
Looks like on the CI default timeout which is 300sec is not enough
and new csr not created during that time, it just take bit more.

```
+ timeout 300 bash -c -- 'until ./openshift-clients/linux/oc get csr | grep Pending; do echo '\''Waiting for first CSR request.'\''; sleep 2; done'

The connection to the server api.crc.testing:6443 was refused - did you specify the right host or port?
Waiting for first CSR request.

Unable to connect to the server: x509: certificate has expired or is not yet valid: current time 2022-01-25T01:32:38-05:00 is after 2022-01-24T18:03:37Z
Waiting for first CSR request.
.....
Unable to connect to the server: x509: certificate has expired or is not yet valid: current time 2022-01-25T01:37:05-05:00 is after 2022-01-24T18:03:37Z
Waiting for first CSR request.
```