### PR TITLE
Enforce a single search registry

### DIFF
--- a/fcos-config.yaml
+++ b/fcos-config.yaml
@@ -182,3 +182,9 @@ storage:
       contents:
         inline: |
           podman.crc.testing
+    - path: /etc/containers/registries.conf.d/999-podman-machine.conf
+      mode: 0644
+      contents:
+        inline: |
+          unqualified-search-registries=["docker.io"]
+


### PR DESCRIPTION
This PR helps user to connect docker client from the host to
podman socket in the instance. As of now even with this PR user
have to manually perform following step to test docker client.
```
$ ssh -nNT -L $(pwd)/docker.sock:/var/run/docker.sock -i /Users/prkumar/.ssh/podman-machine-default -p 64940 root@localhost
<-- different terminal -->
$ export DOCKER_HOST=unix://$(pwd)/docker.sock
$ docker ps
CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
```

This is taken from https://github.com/containers/podman/blob/e06631d6c22f4d5b7a62f70ccdf623379a9d5fe7/pkg/machine/ignition.go#L325-L356