### PR TITLE
Add vfkit bundle generation

### DIFF
--- a/crc-bundle-info.json.sample
+++ b/crc-bundle-info.json.sample
@@ -10,7 +10,8 @@
   # - 1.4: addition of 'arch'
   "version": "1.4",
   # Type of this bundle content
-  # Currently the only valid type is 'snc' (which stands for 'single-node-cluster')
+  # Currently the only valid types are 'snc' (which stands for 'single-node-cluster') and 'podman'
+  # Applications deriving custom bundles from 'snc' and 'podman' must set type to 'snc_custom' or 'podman_custom'
   "type": "snc",
   # Name of the bundle
   "name": "crc_libvirt_4.6.1",

--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -152,6 +152,19 @@ function generate_hyperkit_bundle {
     create_tarball "$destDir"
 }
 
+function generate_vfkit_bundle {
+    local srcDir=$1
+    local destDir=$2
+
+    mkdir "$destDir"
+    generate_macos_bundle "vfkit" $@
+
+    ${QEMU_IMG} convert -f qcow2 -O raw $srcDir/${CRC_VM_NAME}.qcow2 $destDir/${CRC_VM_NAME}.img
+    add_disk_info_to_json_description "${destDir}" "${CRC_VM_NAME}.img" "raw"
+
+    create_tarball "$destDir"
+}
+
 function generate_macos_bundle {
     local bundleType=$1
     local srcDir=$2

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -56,7 +56,7 @@ ${SSH} core@${VM_IP} -- 'sudo rpm-ostree cleanup -r'
 shutdown_vm ${CRC_VM_NAME}
 start_vm ${CRC_VM_NAME} ${VM_IP}
 
-# Only used for hyperkit bundle generation
+# Only used for macOS bundle generation
 if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then
     # Get the rhcos ostree Hash ID
     ostree_hash=$(${SSH} core@${VM_IP} -- "cat /proc/cmdline | grep -oP \"(?<=${BASE_OS}-).*(?=/vmlinuz)\"")
@@ -101,6 +101,14 @@ create_tarball "$libvirtDestDir"
 if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then
     hyperkitDestDir="crc_podman_hyperkit_${destDirSuffix}"
     generate_hyperkit_bundle "$libvirtDestDir" "$hyperkitDestDir" "$1" "$kernel_release" "$kernel_cmd_line"
+fi
+
+# vfkit image generation
+# This must be done after the generation of libvirt image as it reuses some of
+# the content of $libvirtDestDir
+if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then
+    vfkitDestDir="crc_podman_vfkit_${destDirSuffix}"
+    generate_vfkit_bundle "$libvirtDestDir" "$vfkitDestDir" "$1" "$kernel_release" "$kernel_cmd_line"
 fi
 
 # HyperV image generation


### PR DESCRIPTION
This PR adds support for generating vfkit bundles.
I chose to keep hyperkit bundle generation if we want to have a transition phase, code would be simpler if we directly replace the hyperkit generation.
The only difference between hyperkit and vfkit is the disk image, qcow2 in one case, raw in the other.

The same changes for the `master` branch can be found at https://github.com/cfergeau/snc/tree/vfkit (there were conflicts to resolve)

I checked the generated bundle content of vfkit/podman, but did not get a chance to try to run such a bundle.
I did not have time yet to test vfkit/openshift bundle generation.