### PR TITLE
[Cherry-pick] Add arch info to directory before compress

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -248,7 +248,7 @@ function generate_hyperv_bundle {
 function create_tarball {
     local dirName=$1
 
-    tar cSf - --sort=name "$dirName" | ${ZSTD} --no-progress ${CRC_ZSTD_EXTRA_FLAGS} --threads=0 -o "${dirName}_${yq_ARCH}".crcbundle
+    tar cSf - --sort=name "$dirName" | ${ZSTD} --no-progress ${CRC_ZSTD_EXTRA_FLAGS} --threads=0 -o "${dirName}".crcbundle
 }
 
 function download_podman() {

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -88,7 +88,7 @@ download_podman $podman_version
 # libvirt image generation
 destDirSuffix="${podman_version}"
 
-libvirtDestDir="crc_podman_libvirt_${destDirSuffix}"
+libvirtDestDir="crc_podman_libvirt_${destDirSuffix}_${yq_ARCH}"
 mkdir "$libvirtDestDir"
 
 create_qemu_image "$1" "$libvirtDestDir"
@@ -99,7 +99,7 @@ create_tarball "$libvirtDestDir"
 # This must be done after the generation of libvirt image as it reuses some of
 # the content of $libvirtDestDir
 if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then
-    hyperkitDestDir="crc_podman_hyperkit_${destDirSuffix}"
+    hyperkitDestDir="crc_podman_hyperkit_${destDirSuffix}_${yq_ARCH}"
     generate_hyperkit_bundle "$libvirtDestDir" "$hyperkitDestDir" "$1" "$kernel_release" "$kernel_cmd_line"
 fi
 
@@ -107,7 +107,7 @@ fi
 # This must be done after the generation of libvirt image as it reuses some of
 # the content of $libvirtDestDir
 if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then
-    vfkitDestDir="crc_podman_vfkit_${destDirSuffix}"
+    vfkitDestDir="crc_podman_vfkit_${destDirSuffix}_${yq_ARCH}"
     generate_vfkit_bundle "$libvirtDestDir" "$vfkitDestDir" "$1" "$kernel_release" "$kernel_cmd_line"
 fi
 
@@ -116,7 +116,7 @@ fi
 # This must be done after the generation of libvirt image as it reuses some of
 # the content of $libvirtDestDir
 if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ]; then
-    hypervDestDir="crc_podman_hyperv_${destDirSuffix}"
+    hypervDestDir="crc_podman_hyperv_${destDirSuffix}_${yq_ARCH}"
     generate_hyperv_bundle "$libvirtDestDir" "$hypervDestDir"
 fi
 


### PR DESCRIPTION
This will try to resolve following error from crc side when downloaded bundle is used.
```
INFO Uncompressing /Users/prkumar/Downloads/crc_podman_hyperkit_3.4.4_amd64.crcbundle
crc-podman.qcow2: 1.64 GiB / 1.64 GiB [------------------------------------------------------------------------------------------------------------------------------------------] 100.00%
Temporary error: rename /Users/prkumar/.crc/cache/tmp-extract/crc_podman_hyperkit_3.4.4_amd64 /Users/prkumar/.crc/cache/crc_podman_hyperkit_3.4.4_amd64: no such file or directory (x12)
```