### PR TITLE
Append arch as part of get_dest_dir

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -12,6 +12,7 @@ function get_dest_dir {
             DEST_DIR="$(date --iso-8601)"
         fi
     fi
+    DEST_DIR="${DEST_DIR}_${yq_ARCH}"
 }
 
 function sparsify {

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -127,7 +127,7 @@ download_podman $podman_version
 get_dest_dir
 destDirSuffix="${DEST_DIR}"
 
-libvirtDestDir="crc_libvirt_${destDirSuffix}_${yq_ARCH}"
+libvirtDestDir="crc_libvirt_${destDirSuffix}"
 mkdir "$libvirtDestDir"
 
 create_qemu_image "$libvirtDestDir"
@@ -138,7 +138,7 @@ create_tarball "$libvirtDestDir"
 # This must be done after the generation of libvirt image as it reuses some of
 # the content of $libvirtDestDir
 if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then
-    hyperkitDestDir="crc_hyperkit_${destDirSuffix}_${yq_ARCH}"
+    hyperkitDestDir="crc_hyperkit_${destDirSuffix}"
     generate_hyperkit_bundle "$libvirtDestDir" "$hyperkitDestDir" "$1" "$kernel_release" "$kernel_cmd_line"
 fi
 
@@ -146,7 +146,7 @@ fi
 # This must be done after the generation of libvirt image as it reuses some of
 # the content of $libvirtDestDir
 if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then
-    vfkitDestDir="crc_vfkit_${destDirSuffix}_${yq_ARCH}"
+    vfkitDestDir="crc_vfkit_${destDirSuffix}"
     generate_vfkit_bundle "$libvirtDestDir" "$vfkitDestDir" "$1" "$kernel_release" "$kernel_cmd_line"
 fi
 
@@ -155,7 +155,7 @@ fi
 # This must be done after the generation of libvirt image as it reuses some of
 # the content of $libvirtDestDir
 if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ]; then
-    hypervDestDir="crc_hyperv_${destDirSuffix}_${yq_ARCH}"
+    hypervDestDir="crc_hyperv_${destDirSuffix}"
     generate_hyperv_bundle "$libvirtDestDir" "$hypervDestDir"
 fi
 


### PR DESCRIPTION
get_dest_dir can return the full destination directory suffix including
the arch, this is less error-prone this way rather than expecting every
user of destDirSuffix to know yq_ARCH must be appended as well.