### PR TITLE
Use latest-4.10 instead of candidate-4.10

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -41,7 +41,7 @@ if test -n "${OPENSHIFT_VERSION-}"; then
     OPENSHIFT_RELEASE_VERSION=${OPENSHIFT_VERSION}
     echo "Using release ${OPENSHIFT_RELEASE_VERSION} from OPENSHIFT_VERSION"
 else
-    OPENSHIFT_RELEASE_VERSION="$(curl -L "${MIRROR}"/candidate-4.10/release.txt | sed -n 's/^ *Version: *//p')"
+    OPENSHIFT_RELEASE_VERSION="$(curl -L "${MIRROR}"/latest-4.10/release.txt | sed -n 's/^ *Version: *//p')"
     if test -n "${OPENSHIFT_RELEASE_VERSION}"; then
         echo "Using release ${OPENSHIFT_RELEASE_VERSION} from the latest mirror"
     else


### PR DESCRIPTION
candidate-4.10 seems to be gone:

$ curl https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp-dev-preview//candidate-4.10/release.txt
<html>
<body>
<p>File not found</p>
</body>
</html>

We can use latest-4.10 instead:
https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp-dev-preview/latest-4.10/

This fixes https://bugzilla.redhat.com/show_bug.cgi?id=2067327