### PR TITLE
Revert "Change the authorized_keys file permission to core user"

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -72,10 +72,6 @@ cat crio-wipe.service | ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} "sudo tee 
 # Preload routes controller
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo crictl pull quay.io/crcont/routes-controller:latest'
 
-# Change the ownership of authorized_keys file
-# https://bugzilla.redhat.com/show_bug.cgi?id=1956739
-${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- 'sudo chown core.core ~/.ssh/authorized_keys'
-
 # Shutdown and Start the VM after installing the hyperV daemon packages.
 # This is required to get the latest ostree layer which have those installed packages.
 shutdown_vm ${VM_PREFIX}


### PR DESCRIPTION
This reverts commit f4227b5adbd8f237a1f995290eb868f179f3ac3a.

Since https://bugzilla.redhat.com/show_bug.cgi?id=1956739 is now fixed
and available on 4.10.3 onwards.