### PR TITLE
Podman: Add arch info to podman download URI 

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -264,7 +264,7 @@ function download_podman() {
       mkdir -p podman-remote/mac
       curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-release-darwin_${arch}.zip -o podman-remote/mac/podman.zip
       ${UNZIP} -o -d podman-remote/mac/ podman-remote/mac/podman.zip
-      mv podman-remote/mac/podman-${version}/podman  podman-remote/mac
+      mv podman-remote/mac/podman-${version}/usr/bin/podman  podman-remote/mac
       chmod +x podman-remote/mac/podman
     fi
 
@@ -272,6 +272,6 @@ function download_podman() {
       mkdir -p podman-remote/windows
       curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-release-windows_${arch}.zip -o podman-remote/windows/podman.zip
       ${UNZIP} -o -d podman-remote/windows/ podman-remote/windows/podman.zip
-      mv podman-remote/windows/podman-${version}/podman.exe  podman-remote/windows
+      mv podman-remote/windows/podman-${version}/usr/bin/podman.exe  podman-remote/windows
     fi
 }

--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -253,6 +253,7 @@ function create_tarball {
 
 function download_podman() {
     local version=$1
+    local arch=$2
 
     mkdir -p podman-remote/linux
     curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-static.tar.gz | tar -zx -C podman-remote/linux podman-remote-static
@@ -261,7 +262,7 @@ function download_podman() {
 
     if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then
       mkdir -p podman-remote/mac
-      curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-release-darwin.zip -o podman-remote/mac/podman.zip
+      curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-release-darwin_${arch}.zip -o podman-remote/mac/podman.zip
       ${UNZIP} -o -d podman-remote/mac/ podman-remote/mac/podman.zip
       mv podman-remote/mac/podman-${version}/podman  podman-remote/mac
       chmod +x podman-remote/mac/podman
@@ -269,7 +270,7 @@ function download_podman() {
 
     if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ]; then
       mkdir -p podman-remote/windows
-      curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-release-windows.zip -o podman-remote/windows/podman.zip
+      curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-release-windows_${arch}.zip -o podman-remote/windows/podman.zip
       ${UNZIP} -o -d podman-remote/windows/ podman-remote/windows/podman.zip
       mv podman-remote/windows/podman-${version}/podman.exe  podman-remote/windows
     fi

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -83,7 +83,7 @@ ${SSH} core@${VM_IP} -- 'sudo journalctl --vacuum-time=1s'
 shutdown_vm ${CRC_VM_NAME}
 
 # Download podman clients
-download_podman $podman_version
+download_podman $podman_version ${yq_ARCH}
 
 # libvirt image generation
 destDirSuffix="${podman_version}"


### PR DESCRIPTION
From 4.x the name of tarball now includes the arch details and this
PR is to update it.

- https://github.com/containers/podman/releases/tag/v4.0.2