### PR TITLE
Add image format for qemu-rebase

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -68,7 +68,7 @@ function create_qemu_image {
     fi
 
     sudo chown $USER:$USER -R $destDir
-    ${QEMU_IMG} rebase -b ${VM_PREFIX}-base $destDir/${VM_PREFIX}-master-0
+    ${QEMU_IMG} rebase -f qcow2 -F qcow2 -b ${VM_PREFIX}-base $destDir/${VM_PREFIX}-master-0
     ${QEMU_IMG} commit $destDir/${VM_PREFIX}-master-0
 
     sparsify $destDir ${VM_PREFIX}-base ${CRC_VM_NAME}.qcow2


### PR DESCRIPTION
This should fix following error for new version of qemu packages.
```
 qemu-img rebase -b fedora-coreos-qemu.x86_64.qcow2 crc_podman_libvirt_3.4.1/crc-podman.qcow2
qemu-img: Could not change the backing file to 'fedora-coreos-qemu.x86_64.qcow2': backing format must be specified
```

- https://github.com/qemu/qemu/blob/master/docs/about/removed-features.rst#qemu-img-backing-file-without-format-removed-in-61