### PR TITLE
CodeReady Containers was renamed to OpenShift Local

### DIFF
--- a/security-notice.yaml
+++ b/security-notice.yaml
@@ -3,7 +3,7 @@ kind: ConsoleNotification
 metadata:
   name: security-notice
 spec:
-  text: CodeReady Containers OpenShift cluster is for development and testing purposes. DON'T use it for production.
+  text: OpenShift Local cluster is for development and testing purposes. DON'T use it for production.
   location: BannerTop
   color: '#fff'
   backgroundColor: darkred


### PR DESCRIPTION
The old name still appears in the banner displayed at the top of the
OpenShift console https://console-openshift-console.apps-crc.testing

There are still two occurrences of CodeReadyContainers in snc's code:
```
snc.sh:# Add codeReadyContainer as invoker to identify it with telemeter
snc.sh:export OPENSHIFT_INSTALL_INVOKER="codeReadyContainers"
```

Since this is used for installer telemetry, not sure it's wise to change it.