### PR TITLE
increased timeout  for first csr request to 500

### DIFF
--- a/snc-library.sh
+++ b/snc-library.sh
@@ -202,7 +202,7 @@ function renew_certificates() {
     start_vm ${vm_prefix}
 
     # After cluster starts kube-apiserver-client-kubelet signer need to be approved
-    timeout 300 bash -c -- "until ${OC} get csr | grep Pending; do echo 'Waiting for first CSR request.'; sleep 2; done"
+    timeout 500s bash -c -- "until ${OC} get csr | grep Pending; do echo 'Waiting for first CSR request.'; sleep 2; done"
     ${OC} get csr -ojsonpath='{.items[*].metadata.name}' | xargs ${OC} adm certificate approve
 
     # Retry 10 times to make sure kubelet certs are rotated correctly.


### PR DESCRIPTION
Some SNC executions fails due to timeout while waiting for the first CSR request, this PR increase the timeout for waiting for the first CSR to 500