### PR TITLE
Workaround corrupted podman-remote-linux binaries

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -249,7 +249,7 @@ function download_podman() {
     local arch=$2
 
     mkdir -p podman-remote/linux
-    curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-static.tar.gz | tar -zx -C podman-remote/linux podman-remote-static
+    curl -L https://github.com/containers/podman/releases/download/v4.1.1/podman-remote-static.tar.gz | tar -zx -C podman-remote/linux podman-remote-static
     mv podman-remote/linux/podman-remote-static podman-remote/linux/podman-remote
     chmod +x podman-remote/linux/podman-remote
 


### PR DESCRIPTION
The linux static binaries from podman releases 4.0.2 and 4.1.0 available
from github.com/containers/podman are not working:
- the 4.0.2 binary crashes when starting up
- the 4.1.0 binary is a Windows binary instead of being a linux one

The 4.1.1 binary is functional, so this commit temporary hardcodes use
of this version on linux when generating a podman bundle.