### PR TITLE
Refactor createdisk-library.sh to make it closer to the one in the master branch

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -114,19 +114,24 @@ function copy_additional_files {
 
 function install_additional_packages() {
     local vm_ip=$1
+    shift
     ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora.repo'
     ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=0/enabled=1/ /etc/yum.repos.d/fedora-updates.repo'
-    ${SSH} core@${vm_ip} -- 'sudo rpm-ostree install --allow-inactive cockpit-bridge cockpit-ws cockpit-podman'
-    if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ]; then
-        prepare_hyperV ${vm_ip}
-    fi
+    ${SSH} core@${vm_ip} -- "sudo rpm-ostree install --allow-inactive $*"
     ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora.repo'
     ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora-updates.repo'
 }
 
+function prepare_cockpit() {
+    local vm_ip=$1
+
+    install_additional_packages ${vm_ip} cockpit-bridge cockpit-ws cockpit-podman
+}
+
 function prepare_hyperV() {
     local vm_ip=$1
-    ${SSH} core@${vm_ip} -- 'sudo rpm-ostree install --allow-inactive hyperv-daemons'
+
+    install_additional_packages ${vm_ip} hyperv-daemons
 
     # Adding Hyper-V vsock support
     ${SSH} core@${vm_ip} 'sudo bash -x -s' <<EOF

--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -142,7 +142,6 @@ function generate_vfkit_bundle {
     local srcDir=$1
     local destDir=$2
 
-    mkdir "$destDir"
     generate_macos_bundle "vfkit" "$@"
 
     ${QEMU_IMG} convert -f qcow2 -O raw $srcDir/${CRC_VM_NAME}.qcow2 $destDir/${CRC_VM_NAME}.img

--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -44,11 +44,10 @@ EOF
 }
 
 function create_qemu_image {
-    local sourceDir=$1
-    local destDir=$2
+    local destDir=$1
 
     sudo cp /var/lib/libvirt/images/${CRC_VM_NAME}.qcow2 $destDir
-    sudo cp ${sourceDir}/fedora-coreos-qemu.${ARCH}.qcow2 $destDir
+    sudo cp /var/lib/libvirt/images/fedora-coreos-qemu.${ARCH}.qcow2 $destDir
 
     sudo chown $USER:$USER -R $destDir
     ${QEMU_IMG} rebase -f qcow2 -F qcow2 -b fedora-coreos-qemu.${ARCH}.qcow2 $destDir/${CRC_VM_NAME}.qcow2

--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -2,6 +2,14 @@
 
 set -exuo pipefail
 
+function get_dest_dir_suffix {
+    local version=$1
+    DEST_DIR_SUFFIX="${version}_${yq_ARCH}"
+    if [ -n "${PULL_NUMBER-}" ]; then
+         DEST_DIR_SUFFIX="$DEST_DIR_SUFFIX.pr${PULL_NUMBER}"
+    fi
+}
+
 function sparsify {
     local baseDir=$1
     local srcFile=$2

--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -51,7 +51,7 @@ function create_qemu_image {
     sudo cp ${sourceDir}/fedora-coreos-qemu.${ARCH}.qcow2 $destDir
 
     sudo chown $USER:$USER -R $destDir
-    ${QEMU_IMG} rebase -F qcow2 -b fedora-coreos-qemu.${ARCH}.qcow2 $destDir/${CRC_VM_NAME}.qcow2
+    ${QEMU_IMG} rebase -f qcow2 -F qcow2 -b fedora-coreos-qemu.${ARCH}.qcow2 $destDir/${CRC_VM_NAME}.qcow2
     ${QEMU_IMG} commit $destDir/${CRC_VM_NAME}.qcow2
 
     sparsify $destDir fedora-coreos-qemu.${ARCH}.qcow2 ${CRC_VM_NAME}.qcow2

--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -45,20 +45,26 @@ EOF
 
 function create_qemu_image {
     local destDir=$1
+    local base=$2
+    local overlay=$3
 
-    sudo cp /var/lib/libvirt/images/${CRC_VM_NAME}.qcow2 $destDir
-    sudo cp /var/lib/libvirt/images/fedora-coreos-qemu.${ARCH}.qcow2 $destDir
+    if [ -f /var/lib/libvirt/images/${overlay} ]; then
+      sudo cp /var/lib/libvirt/images/${overlay} ${destDir}
+      sudo cp /var/lib/libvirt/images/${base} ${destDir}
+    else
+      sudo cp /var/lib/libvirt/openshift-images/${VM_PREFIX}/${overlay} ${destDir}
+      sudo cp /var/lib/libvirt/openshift-images/${VM_PREFIX}/${base} ${destDir}
+    fi
 
-    sudo chown $USER:$USER -R $destDir
-    ${QEMU_IMG} rebase -f qcow2 -F qcow2 -b fedora-coreos-qemu.${ARCH}.qcow2 $destDir/${CRC_VM_NAME}.qcow2
-    ${QEMU_IMG} commit $destDir/${CRC_VM_NAME}.qcow2
+    sudo chown $USER:$USER -R ${destDir}
+    ${QEMU_IMG} rebase -f qcow2 -F qcow2 -b ${base} ${destDir}/${overlay}
+    ${QEMU_IMG} commit ${destDir}/${overlay}
 
-    sparsify $destDir fedora-coreos-qemu.${ARCH}.qcow2 ${CRC_VM_NAME}.qcow2
+    sparsify ${destDir} ${base} ${overlay}
 
-    # Update the qcow2 image permission from 0600 to 0644
-    chmod 0644 ${destDir}/${CRC_VM_NAME}.qcow2
+    chmod 0644 ${destDir}/${overlay}
 
-    rm -fr $destDir/fedora-coreos-qemu.${ARCH}.qcow2
+    rm -fr ${destDir}/${base}
 }
 
 function update_json_description {

--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -122,8 +122,6 @@ function install_additional_packages() {
     fi
     ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora.repo'
     ${SSH} core@${vm_ip} -- 'sudo sed -i -z s/enabled=1/enabled=0/ /etc/yum.repos.d/fedora-updates.repo'
-    ${SSH} core@${vm_ip} -- 'sudo rpm-ostree cleanup --base'
-    ${SSH} core@${vm_ip} -- 'sudo rpm-ostree cleanup --repomd'
 }
 
 function prepare_hyperV() {

--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -56,13 +56,6 @@ function create_qemu_image {
 
     sparsify $destDir fedora-coreos-qemu.${ARCH}.qcow2 ${CRC_VM_NAME}.qcow2
 
-    # Before using the created qcow2, check if it has lazy_refcounts set to true.
-    ${QEMU_IMG} info ${destDir}/${CRC_VM_NAME}.qcow2 | grep "lazy refcounts: true" 2>&1 >/dev/null
-    if [ $? -ne 0 ]; then
-        echo "${CRC_VM_NAME}.qcow2 doesn't have lazy_refcounts enabled. This is going to cause disk image corruption when using with hyperkit"
-        exit 1;
-    fi
-
     # Update the qcow2 image permission from 0600 to 0644
     chmod 0644 ${destDir}/${CRC_VM_NAME}.qcow2
 

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -43,8 +43,8 @@ ${SSH} core@${VM_IP} -- 'touch ~/.ssh/authorized_keys && chmod 0600 ~/.ssh/autho
 shutdown_vm ${CRC_VM_NAME}
 start_vm ${CRC_VM_NAME} ${VM_IP}
 
-# Remove the base deployment from rpm-ostree
-${SSH} core@${VM_IP} -- 'sudo rpm-ostree cleanup -r'
+# Remove miscellaneous unneeded data from rpm-ostree
+${SSH} core@${VM_IP} -- 'sudo rpm-ostree cleanup --rollback --base --repomd'
 # Shutdown and Start the VM after removing base deployment tree
 # This is required because kernel commandline changed, namely
 # ostree=/ostree/boot.1/fedora-coreos/$hash/0 which switches 

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -87,7 +87,7 @@ destDirSuffix="${podman_version}"
 libvirtDestDir="crc_podman_libvirt_${destDirSuffix}_${yq_ARCH}"
 mkdir "$libvirtDestDir"
 
-create_qemu_image "$INSTALL_DIR" "$libvirtDestDir"
+create_qemu_image "$libvirtDestDir"
 copy_additional_files "$INSTALL_DIR" "$libvirtDestDir" "$podman_version"
 create_tarball "$libvirtDestDir"
 

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -24,7 +24,8 @@ ${SSH} core@${VM_IP} -- 'sudo find /var/log/ -iname "*.log" -exec rm -f {} \;'
 # Remove moby-engine package
 ${SSH} core@${VM_IP} -- 'sudo rpm-ostree override remove moby-engine'
 
-install_additional_packages ${VM_IP}
+prepare_cockpit ${VM_IP}
+prepare_hyperV ${VM_IP}
 
 # Add gvisor-tap-vsock
 ${SSH} core@${VM_IP} 'sudo bash -x -s' <<EOF

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -87,7 +87,7 @@ destDirSuffix="${podman_version}"
 libvirtDestDir="crc_podman_libvirt_${destDirSuffix}_${yq_ARCH}"
 mkdir "$libvirtDestDir"
 
-create_qemu_image "$libvirtDestDir"
+create_qemu_image "$libvirtDestDir" "fedora-coreos-qemu.${ARCH}.qcow2" "${CRC_VM_NAME}.qcow2"
 copy_additional_files "$INSTALL_DIR" "$libvirtDestDir" "$podman_version"
 create_tarball "$libvirtDestDir"
 

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -35,10 +35,6 @@ ${SSH} core@${VM_IP} 'sudo bash -x -s' <<EOF
   systemctl enable gvisor-tap-vsock.service
 EOF
 
-# Change the ownership of authorized_keys file
-# https://bugzilla.redhat.com/show_bug.cgi?id=1956739
-${SSH} core@${VM_IP} -- 'touch ~/.ssh/authorized_keys && chmod 0600 ~/.ssh/authorized_keys'
-
 # Shutdown and Start the VM after modifying the set of installed packages
 # This is required to get the latest ostree layer which have those installed packages.
 shutdown_vm ${CRC_VM_NAME}

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -79,9 +79,10 @@ shutdown_vm ${CRC_VM_NAME}
 download_podman $podman_version ${yq_ARCH}
 
 # libvirt image generation
-destDirSuffix="${podman_version}"
+get_dest_dir_suffix "${podman_version}"
+destDirSuffix="${DEST_DIR_SUFFIX}"
 
-libvirtDestDir="crc_podman_libvirt_${destDirSuffix}_${yq_ARCH}"
+libvirtDestDir="crc_podman_libvirt_${destDirSuffix}"
 mkdir "$libvirtDestDir"
 
 create_qemu_image "$libvirtDestDir" "fedora-coreos-qemu.${ARCH}.qcow2" "${CRC_VM_NAME}.qcow2"
@@ -92,7 +93,7 @@ create_tarball "$libvirtDestDir"
 # This must be done after the generation of libvirt image as it reuses some of
 # the content of $libvirtDestDir
 if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then
-    vfkitDestDir="crc_podman_vfkit_${destDirSuffix}_${yq_ARCH}"
+    vfkitDestDir="crc_podman_vfkit_${destDirSuffix}"
     generate_vfkit_bundle "$libvirtDestDir" "$vfkitDestDir" "$INSTALL_DIR" "$kernel_release" "$kernel_cmd_line"
 fi
 
@@ -101,7 +102,7 @@ fi
 # This must be done after the generation of libvirt image as it reuses some of
 # the content of $libvirtDestDir
 if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ]; then
-    hypervDestDir="crc_podman_hyperv_${destDirSuffix}_${yq_ARCH}"
+    hypervDestDir="crc_podman_hyperv_${destDirSuffix}"
     generate_hyperv_bundle "$libvirtDestDir" "$hypervDestDir"
 fi
 

--- a/snc.sh
+++ b/snc.sh
@@ -42,7 +42,7 @@ ${PODMAN} run --pull=always --rm -i quay.io/coreos/ignition-validate:release - <
 
 # Download the latest fedora coreos latest qcow2
 ${PODMAN} run --pull=always --rm -v ${PWD}/${CRC_INSTALL_DIR}:/data:Z -w /data quay.io/coreos/coreos-installer:release download -a ${ARCH} -s stable -p qemu -f qcow2.xz --decompress
-mv ${CRC_INSTALL_DIR}/fedora-coreos-*-qemu.${ARCH}.qcow2 ${CRC_INSTALL_DIR}/fedora-coreos-qemu.${ARCH}.qcow2
+sudo mv ${CRC_INSTALL_DIR}/fedora-coreos-*-qemu.${ARCH}.qcow2 /var/lib/libvirt/images/fedora-coreos-qemu.${ARCH}.qcow2
 
 # Update the selinux context for ign config and ${CRC_INSTALL_DIR}
 chcon --verbose ${current_selinux_context} ${CRC_INSTALL_DIR}
@@ -56,7 +56,7 @@ create_json_description
 sudo ${VIRT_INSTALL} --name=${CRC_VM_NAME} --vcpus=2 --ram=2048 --arch=${ARCH}\
 	--import --graphics=none \
 	--qemu-commandline="-fw_cfg name=opt/com.coreos/config,file=${PWD}/${CRC_INSTALL_DIR}/fcos-config.ign" \
-	--disk=size=31,backing_store=${PWD}/${CRC_INSTALL_DIR}/fedora-coreos-qemu.${ARCH}.qcow2 \
+	--disk=size=31,backing_store=/var/lib/libvirt/images/fedora-coreos-qemu.${ARCH}.qcow2 \
 	--os-variant=fedora-coreos-stable \
 	--noautoconsole --quiet
 sleep 120


### PR DESCRIPTION
This is the PR for the podman branch corresponding to https://github.com/code-ready/snc/pull/534

After it, the only differences between createdisk-library.sh in both branch are
in update_json_description, copy_additional_files, generate_macos_bundle,
generate_hyperv_bundle because they need different files (podman, oc, kubeconfig, ...), and in create_tarball but this difference will be gone when we switch to openshift 4.11 which has podman4

The difference in bundle generation is a bit more complicated to handle in shell, this is why it's not dealt with for now.