### PR TITLE
Change network type to OVNKubernetes from OpenshiftSDN

### DIFF
--- a/install-config.yaml
+++ b/install-config.yaml
@@ -23,7 +23,7 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 192.168.126.0/24
-  networkType: OpenShiftSDN
+  networkType: OVNKubernetes
   serviceNetwork:
   - 10.217.4.0/23
 platform:


### PR DESCRIPTION
OpenshiftSDN is deprecated and replace with OVNKubernetes and this
PR makes that change.
- https://docs.openshift.com/container-platform/4.10/installing/installing_sno/install-sno-preparing-to-install-sno.html