### PR TITLE
install-config: Don't specify networkType

### DIFF
--- a/install-config.yaml
+++ b/install-config.yaml
@@ -23,7 +23,6 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 192.168.126.0/24
-  networkType: OVNKubernetes
   serviceNetwork:
   - 10.217.4.0/23
 platform:


### PR DESCRIPTION
We want to use the value OpenShift is using by default, and the field is
optional:
https://github.com/openshift/installer/blob/release-4.10/docs/user/customization.md
```
networkType (optional string): The type of network to install. The default is OpenShiftSDN.
```
This commit removes the setting of networkType in install-config.yaml,
this way we'll always be using the value OpenShift wants to use by
default.