### PR TITLE
[Cherry-pick] Use quay.io/crcont/gvisor-tap-vsock:latest

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -57,7 +57,7 @@ fi
 
 # Add gvisor-tap-vsock and crc-dnsmasq services
 ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} 'sudo bash -x -s' <<EOF
-  podman create --name=gvisor-tap-vsock --privileged --net=host -v /etc/resolv.conf:/etc/resolv.conf -it quay.io/crcont/gvisor-tap-vsock:3231aba53905468c22e394493a0debc1a6cc6392
+  podman create --name=gvisor-tap-vsock --privileged --net=host -v /etc/resolv.conf:/etc/resolv.conf -it quay.io/crcont/gvisor-tap-vsock:latest
   podman generate systemd --restart-policy=no gvisor-tap-vsock > /etc/systemd/system/gvisor-tap-vsock.service
   touch /var/srv/dnsmasq.conf
   podman create --ip 10.88.0.8 --name crc-dnsmasq -v /var/srv/dnsmasq.conf:/etc/dnsmasq.conf -p 53:53/udp --privileged quay.io/crcont/dnsmasq:latest


### PR DESCRIPTION
snc currently uses
quay.io/crcont/gvisor-tap-vsock:3231aba53905468c22e394493a0debc1a6cc6392
which is not multiarch.
This commit uses the latest tag instead which has both aarch64 and
x86_64 builds.