### PR TITLE
Revert "Change network type to OVNKubernetes from OpenshiftSDN"

### DIFF
--- a/install-config.yaml
+++ b/install-config.yaml
@@ -23,7 +23,7 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 192.168.126.0/24
-  networkType: OVNKubernetes
+  networkType: OpenShiftSDN
   serviceNetwork:
   - 10.217.4.0/23
 platform:


### PR DESCRIPTION
This reverts commit e4a2d40e6ded085d1d59d4357af62c21e3cce2ed.

During our testing of the bundle with OVN looks like the resource
usage is high for ovn pods than sdn. So during cluster reconcile
it break when using default mem/cpu for crc.

```
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  Resource           Requests      Limits
  --------           --------      ------
  cpu                1990m (52%)   0 (0%)
  memory             8480Mi (99%)  0 (0%)
  ephemeral-storage  0 (0%)        0 (0%)
  hugepages-1Gi      0 (0%)        0 (0%)
  hugepages-2Mi      0 (0%)        0 (0%)
```