### PR TITLE
Add cifs-utils package to hyperV bundle

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -158,7 +158,7 @@ function prepare_cockpit() {
 function prepare_hyperV() {
     local vm_ip=$1
 
-    install_additional_packages ${vm_ip} hyperv-daemons
+    install_additional_packages ${vm_ip} hyperv-daemons cifs-utils
 
     # Adding Hyper-V vsock support
     ${SSH} core@${vm_ip} 'sudo bash -x -s' <<EOF


### PR DESCRIPTION
this package provides utilities for managing mounts
of CIFS network file systems

its needed to make use of windows default  CIFS/SMB
feature for network file sharing between hosts