### PR TITLE
Add logic to create custom release after patching KAO/KCMO

### DIFF
--- a/cluster-kube-apiserver-operator.patch
+++ b/cluster-kube-apiserver-operator.patch
@@ -1,0 +1,183 @@
+diff --git a/pkg/operator/certrotationcontroller/certrotationcontroller.go b/pkg/operator/certrotationcontroller/certrotationcontroller.go
+index 1bf5d3224..a28ce71ed 100644
+--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
++++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
+@@ -129,8 +129,8 @@ func newCertRotationController(
+ 		certrotation.RotatedSigningCASecret{
+ 			Namespace:              operatorclient.OperatorNamespace,
+ 			Name:                   "aggregator-client-signer",
+-			Validity:               30 * rotationDay,
+-			Refresh:                15 * rotationDay,
++			Validity:               365 * rotationDay,
++			Refresh:                180 * rotationDay,
+ 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+ 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
+ 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
+@@ -148,8 +148,8 @@ func newCertRotationController(
+ 		certrotation.RotatedSelfSignedCertKeySecret{
+ 			Namespace:              operatorclient.TargetNamespace,
+ 			Name:                   "aggregator-client",
+-			Validity:               30 * rotationDay,
+-			Refresh:                15 * rotationDay,
++			Validity:               365 * rotationDay,
++			Refresh:                180 * rotationDay,
+ 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+ 			CertCreator: &certrotation.ClientRotation{
+ 				UserInfo: &user.DefaultInfo{Name: "system:openshift-aggregator"},
+@@ -188,8 +188,8 @@ func newCertRotationController(
+ 		certrotation.RotatedSelfSignedCertKeySecret{
+ 			Namespace:              operatorclient.TargetNamespace,
+ 			Name:                   "kubelet-client",
+-			Validity:               30 * rotationDay,
+-			Refresh:                15 * rotationDay,
++			Validity:               365 * rotationDay,
++			Refresh:                180 * rotationDay,
+ 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+ 			CertCreator: &certrotation.ClientRotation{
+ 				UserInfo: &user.DefaultInfo{Name: "system:kube-apiserver", Groups: []string{"kube-master"}},
+@@ -228,8 +228,8 @@ func newCertRotationController(
+ 		certrotation.RotatedSelfSignedCertKeySecret{
+ 			Namespace:              operatorclient.TargetNamespace,
+ 			Name:                   "localhost-serving-cert-certkey",
+-			Validity:               30 * rotationDay,
+-			Refresh:                15 * rotationDay,
++			Validity:               365 * rotationDay,
++			Refresh:                180 * rotationDay,
+ 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+ 			CertCreator: &certrotation.ServingRotation{
+ 				Hostnames: func() []string { return []string{"localhost", "127.0.0.1"} },
+@@ -268,8 +268,8 @@ func newCertRotationController(
+ 		certrotation.RotatedSelfSignedCertKeySecret{
+ 			Namespace:              operatorclient.TargetNamespace,
+ 			Name:                   "service-network-serving-certkey",
+-			Validity:               30 * rotationDay,
+-			Refresh:                15 * rotationDay,
++			Validity:               365 * rotationDay,
++			Refresh:                180 * rotationDay,
+ 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+ 			CertCreator: &certrotation.ServingRotation{
+ 				Hostnames:        ret.serviceNetwork.GetHostnames,
+@@ -309,8 +309,8 @@ func newCertRotationController(
+ 		certrotation.RotatedSelfSignedCertKeySecret{
+ 			Namespace:              operatorclient.TargetNamespace,
+ 			Name:                   "external-loadbalancer-serving-certkey",
+-			Validity:               30 * rotationDay,
+-			Refresh:                15 * rotationDay,
++			Validity:               365 * rotationDay,
++			Refresh:                180 * rotationDay,
+ 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+ 			CertCreator: &certrotation.ServingRotation{
+ 				Hostnames:        ret.externalLoadBalancer.GetHostnames,
+@@ -350,8 +350,8 @@ func newCertRotationController(
+ 		certrotation.RotatedSelfSignedCertKeySecret{
+ 			Namespace:              operatorclient.TargetNamespace,
+ 			Name:                   "internal-loadbalancer-serving-certkey",
+-			Validity:               30 * rotationDay,
+-			Refresh:                15 * rotationDay,
++			Validity:               365 * rotationDay,
++			Refresh:                180 * rotationDay,
+ 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+ 			CertCreator: &certrotation.ServingRotation{
+ 				Hostnames:        ret.internalLoadBalancer.GetHostnames,
+@@ -410,8 +410,8 @@ func newCertRotationController(
+ 		certrotation.RotatedSigningCASecret{
+ 			Namespace:              operatorclient.OperatorNamespace,
+ 			Name:                   "kube-control-plane-signer",
+-			Validity:               60 * defaultRotationDay,
+-			Refresh:                30 * defaultRotationDay,
++			Validity:               2 * 365 * defaultRotationDay,
++			Refresh:                365 * defaultRotationDay,
+ 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+ 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
+ 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
+@@ -429,8 +429,8 @@ func newCertRotationController(
+ 		certrotation.RotatedSelfSignedCertKeySecret{
+ 			Namespace:              operatorclient.GlobalMachineSpecifiedConfigNamespace,
+ 			Name:                   "kube-controller-manager-client-cert-key",
+-			Validity:               30 * rotationDay,
+-			Refresh:                15 * rotationDay,
++			Validity:               365 * rotationDay,
++			Refresh:                180 * rotationDay,
+ 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+ 			CertCreator: &certrotation.ClientRotation{
+ 				UserInfo: &user.DefaultInfo{Name: "system:kube-controller-manager"},
+@@ -450,8 +450,8 @@ func newCertRotationController(
+ 		certrotation.RotatedSigningCASecret{
+ 			Namespace:              operatorclient.OperatorNamespace,
+ 			Name:                   "kube-control-plane-signer",
+-			Validity:               60 * defaultRotationDay,
+-			Refresh:                30 * defaultRotationDay,
++			Validity:               2 * 365 * defaultRotationDay,
++			Refresh:                365 * defaultRotationDay,
+ 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+ 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
+ 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
+@@ -469,8 +469,8 @@ func newCertRotationController(
+ 		certrotation.RotatedSelfSignedCertKeySecret{
+ 			Namespace:              operatorclient.GlobalMachineSpecifiedConfigNamespace,
+ 			Name:                   "kube-scheduler-client-cert-key",
+-			Validity:               30 * rotationDay,
+-			Refresh:                15 * rotationDay,
++			Validity:               365 * rotationDay,
++			Refresh:                180 * rotationDay,
+ 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+ 			CertCreator: &certrotation.ClientRotation{
+ 				UserInfo: &user.DefaultInfo{Name: "system:kube-scheduler"},
+@@ -490,8 +490,8 @@ func newCertRotationController(
+ 		certrotation.RotatedSigningCASecret{
+ 			Namespace:              operatorclient.OperatorNamespace,
+ 			Name:                   "kube-control-plane-signer",
+-			Validity:               60 * defaultRotationDay,
+-			Refresh:                30 * defaultRotationDay,
++			Validity:               2 * 365 * defaultRotationDay,
++			Refresh:                365 * defaultRotationDay,
+ 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+ 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
+ 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
+@@ -509,8 +509,8 @@ func newCertRotationController(
+ 		certrotation.RotatedSelfSignedCertKeySecret{
+ 			Namespace:              operatorclient.TargetNamespace,
+ 			Name:                   "control-plane-node-admin-client-cert-key",
+-			Validity:               30 * rotationDay,
+-			Refresh:                15 * rotationDay,
++			Validity:               365 * rotationDay,
++			Refresh:                180 * rotationDay,
+ 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+ 			CertCreator: &certrotation.ClientRotation{
+ 				UserInfo: &user.DefaultInfo{Name: "system:control-plane-node-admin", Groups: []string{"system:masters"}},
+@@ -530,8 +530,8 @@ func newCertRotationController(
+ 		certrotation.RotatedSigningCASecret{
+ 			Namespace:              operatorclient.OperatorNamespace,
+ 			Name:                   "kube-control-plane-signer",
+-			Validity:               60 * defaultRotationDay,
+-			Refresh:                30 * defaultRotationDay,
++			Validity:               2 * 365 * defaultRotationDay,
++			Refresh:                365 * defaultRotationDay,
+ 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+ 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
+ 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
+@@ -549,8 +549,8 @@ func newCertRotationController(
+ 		certrotation.RotatedSelfSignedCertKeySecret{
+ 			Namespace:              operatorclient.TargetNamespace,
+ 			Name:                   "check-endpoints-client-cert-key",
+-			Validity:               30 * rotationDay,
+-			Refresh:                15 * rotationDay,
++			Validity:               365 * rotationDay,
++			Refresh:                180 * rotationDay,
+ 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+ 			CertCreator: &certrotation.ClientRotation{
+ 				UserInfo: &user.DefaultInfo{Name: "system:serviceaccount:openshift-kube-apiserver:check-endpoints"},
+@@ -592,9 +592,9 @@ func newCertRotationController(
+ 			// This needs to live longer then control plane certs so there is high chance that if a cluster breaks
+ 			// because of expired certs these are still valid to use for collecting data using localhost-recovery
+ 			// endpoint with long lived serving certs for localhost.
+-			Validity: 120 * defaultRotationDay,
+-			// We rotate sooner so certs are always valid for 90 days (30 days more then kube-control-plane-signer)
+-			Refresh:                30 * defaultRotationDay,
++			Validity: 3 * 365 * defaultRotationDay,
++			// We rotate sooner so certs are always valid for 90 days (365 days more then kube-control-plane-signer)
++			Refresh:                365 * defaultRotationDay,
+ 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+ 			CertCreator: &certrotation.ClientRotation{
+ 				UserInfo: &user.DefaultInfo{
+

--- a/cluster-kube-controller-manager-operator.patch
+++ b/cluster-kube-controller-manager-operator.patch
@@ -1,0 +1,40 @@
+diff --git a/bindata/assets/config/defaultconfig.yaml b/bindata/assets/config/defaultconfig.yaml
+index d22e9f9e..a9076801 100644
+--- a/bindata/assets/config/defaultconfig.yaml
++++ b/bindata/assets/config/defaultconfig.yaml
+@@ -27,7 +27,7 @@ extendedArguments:
+   - "-bootstrapsigner"
+   - "-tokencleaner"
+   cluster-signing-duration:
+-  - "720h"
++  - "8760h"
+   secure-port:
+   - "10257"
+   cert-dir:
+diff --git a/pkg/operator/certrotationcontroller/certrotationcontroller.go b/pkg/operator/certrotationcontroller/certrotationcontroller.go
+index 0d328e24..01941a28 100644
+--- a/pkg/operator/certrotationcontroller/certrotationcontroller.go
++++ b/pkg/operator/certrotationcontroller/certrotationcontroller.go
+@@ -85,8 +85,8 @@ func newCertRotationController(
+ 			Namespace: operatorclient.OperatorNamespace,
+ 			// this is not a typo, this is the signer of the signer
+ 			Name:                   "csr-signer-signer",
+-			Validity:               60 * rotationDay,
+-			Refresh:                30 * rotationDay,
++			Validity:               2 * 365 * rotationDay,
++			Refresh:                365 * rotationDay,
+ 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+ 			Informer:               kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets(),
+ 			Lister:                 kubeInformersForNamespaces.InformersFor(operatorclient.OperatorNamespace).Core().V1().Secrets().Lister(),
+@@ -104,8 +104,8 @@ func newCertRotationController(
+ 		certrotation.RotatedSelfSignedCertKeySecret{
+ 			Namespace:              operatorclient.OperatorNamespace,
+ 			Name:                   "csr-signer",
+-			Validity:               30 * rotationDay,
+-			Refresh:                15 * rotationDay,
++			Validity:               2 * 365 * rotationDay,
++			Refresh:                365 * rotationDay,
+ 			RefreshOnlyWhenExpired: refreshOnlyWhenExpired,
+ 			CertCreator: &certrotation.SignerRotation{
+ 				SignerName: "kube-csr-signer",
+

--- a/snc-library.sh
+++ b/snc-library.sh
@@ -26,6 +26,21 @@ function download_oc() {
     fi
 }
 
+function create_new_release_with_patched_images() {
+    upstream_registry=quay.io/crcont
+    openshift_version=$(${OC} adm release info -a ${OPENSHIFT_PULL_SECRET_PATH} ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} -ojsonpath='{.config.config.Labels.io\.openshift\.release}')
+    # As of now `oc adm release new` not able to parse images which have multiple arch manifest file so we first need to get the digest of the image for specific
+    # arch and then use that digest with `oc adm release new`.
+    kao_image_digest=$(${OC} image info -a ${OPENSHIFT_PULL_SECRET_PATH} ${upstream_registry}/openshift-crc-cluster-kube-apiserver-operator:${openshift_version} --filter-by-os=linux/${yq_ARCH} -ojson | jq -r .digest)
+    kcmo_image_digest=$(${OC} image info -a ${OPENSHIFT_PULL_SECRET_PATH} ${upstream_registry}/openshift-crc-cluster-kube-controller-manager-operator:${openshift_version} --filter-by-os=linux/${yq_ARCH} -ojson | jq -r .digest)
+
+    ${OC} adm release new -a ${OPENSHIFT_PULL_SECRET_PATH} --from-release=${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} \
+	    cluster-kube-apiserver-operator=${upstream_registry}/openshift-crc-cluster-kube-apiserver-operator@${kao_image_digest} \
+	    cluster-kube-controller-manager-operator=${upstream_registry}/openshift-crc-cluster-kube-controller-manager-operator@${kcmo_image_digest} \
+	    --to-image=quay.io/crcont/ocp-release:${openshift_version}
+    # Replace the release image override with crcont image
+    OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=quay.io/crcont/ocp-release:${openshift_version}
+}
 
 function run_preflight_checks() {
         if [ -z "${OPENSHIFT_PULL_SECRET_PATH-}" ]; then


### PR DESCRIPTION
Currently after bootstrap cert rotation, cert validity become 30 days
which is affecting crc users (who start cluster after 30 day). In this
PR we are adding patch to kube-apiserver-operator (KAO) and
kube-controller-manager-operator (KCMO) increase this limit to 1 year.

We are also creating custom release and use that to create cluster
initially.

How to test
-----------
- Update the pull secret file which should have auth for `quay.io/crcont` and `registry.ci.openshift.org` 
To get the credentials for `registry.ci.openshift.org` check https://docs.ci.openshift.org/docs/how-tos/use-registries-in-build-farm/#how-do-i-log-in-to-pull-images-that-require-authentication and the token would be valid for a month https://docs.ci.openshift.org/docs/how-tos/use-registries-in-build-farm/#i-have-logged-in-to-the-registry-in-the-past 
```
$ SNC_USE_PATCHED_KAO_KCMO_IMAGE=enabled snc.sh 
```