### PR TITLE
Backport a few patches from the podman branch

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -11,6 +11,8 @@ source createdisk-library.sh
 SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
 SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
 
+INSTALL_DIR=${1:-crc-tmp-install-data}
+
 # If the user set OKD_VERSION in the environment, then use it to set BASE_OS
 OKD_VERSION=${OKD_VERSION:-none}
 destDirPrefix="crc"
@@ -20,7 +22,7 @@ then
     destDirPrefix="crc_okd"
 fi
 BASE_OS=${BASE_OS:-rhcos}
-OPENSHIFT_VERSION=$(${JQ} -r .clusterInfo.openshiftVersion $1/crc-bundle-info.json)
+OPENSHIFT_VERSION=$(${JQ} -r .clusterInfo.openshiftVersion $INSTALL_DIR/crc-bundle-info.json)
 
 # CRC_VM_NAME: short VM name to use in crc_libvirt.sh
 # BASE_DOMAIN: domain used for the cluster
@@ -28,10 +30,6 @@ OPENSHIFT_VERSION=$(${JQ} -r .clusterInfo.openshiftVersion $1/crc-bundle-info.js
 CRC_VM_NAME=${CRC_VM_NAME:-crc}
 BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
 
-if [[ $# -ne 1 ]]; then
-   echo "You need to provide the running cluster directory to copy kubeconfig"
-   exit 1
-fi
 
 VM_PREFIX=$(get_vm_prefix ${CRC_VM_NAME})
 
@@ -98,7 +96,7 @@ if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then
     ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- "mkdir /tmp/kernel && sudo cp -r /boot/ostree/${BASE_OS}-${ostree_hash}/*${kernel_release}* /tmp/kernel && sudo chmod 644 /tmp/kernel/initramfs*"
 
     # SCP the vmlinuz/initramfs from VM to Host in provided folder.
-    ${SCP} -r core@api.${CRC_VM_NAME}.${BASE_DOMAIN}:/tmp/kernel/* $1
+    ${SCP} -r core@api.${CRC_VM_NAME}.${BASE_DOMAIN}:/tmp/kernel/* $INSTALL_DIR
 
     ${SSH} core@api.${CRC_VM_NAME}.${BASE_DOMAIN} -- "sudo rm -fr /tmp/kernel"
 fi
@@ -139,7 +137,7 @@ mkdir "$libvirtDestDir"
 
 create_qemu_image "$libvirtDestDir" "${VM_PREFIX}-base" "${VM_PREFIX}-master-0"
 mv "${libvirtDestDir}/${VM_PREFIX}-master-0" "${libvirtDestDir}/${CRC_VM_NAME}.qcow2"
-copy_additional_files "$1" "$libvirtDestDir"
+copy_additional_files "$INSTALL_DIR" "$libvirtDestDir"
 create_tarball "$libvirtDestDir"
 
 # vfkit image generation
@@ -147,7 +145,7 @@ create_tarball "$libvirtDestDir"
 # the content of $libvirtDestDir
 if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then
     vfkitDestDir="${destDirPrefix}_vfkit_${destDirSuffix}"
-    generate_vfkit_bundle "$libvirtDestDir" "$vfkitDestDir" "$1" "$kernel_release" "$kernel_cmd_line"
+    generate_vfkit_bundle "$libvirtDestDir" "$vfkitDestDir" "$INSTALL_DIR" "$kernel_release" "$kernel_cmd_line"
 fi
 
 # HyperV image generation
@@ -160,4 +158,4 @@ if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ]; then
 fi
 
 # Cleanup up vmlinux/initramfs files
-rm -fr "$1/vmlinuz*" "$1/initramfs*"
+rm -fr "$INSTALL_DIR/vmlinuz*" "$INSTALL_DIR/initramfs*"

--- a/snc-library.sh
+++ b/snc-library.sh
@@ -45,15 +45,15 @@ function run_preflight_checks() {
         fi
 
 	if ! virsh -c ${LIBVIRT_URI} net-info default &> /dev/null; then
-		echo "Default libvirt network is not available. Exiting now!"
-		exit 1
+		echo "Installing libvirt default network configuration"
+		sudo dnf install -y libvirt-daemon-config-network || exit 1
 	fi
-	echo "default network is available"
+	echo "default libvirt network is available"
 
 	#Check if default libvirt network is Active
 	if [[ $(virsh -c ${LIBVIRT_URI}  net-info default | awk '{print $2}' | sed '3q;d') == "no" ]]; then
-		echo "Default network is not active. Exiting now!"
-		exit 1
+		echo "Default network is not active, starting it"
+		sudo virsh -c ${LIBVIRT_URI} net-start default || exit 1
 	fi
 
 	#Just warn if architecture is not supported

--- a/tools.sh
+++ b/tools.sh
@@ -72,7 +72,7 @@ if ! rpm -q libguestfs-xfs; then
     sudo yum install libguestfs-xfs
 fi
 
-if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ];then
+if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" -o -n "${SNC_GENERATE_MACOS_BUNDLE}" ];then
     if ! which ${UNZIP}; then
         sudo yum -y install /usr/bin/unzip
     fi


### PR DESCRIPTION
While testing bundle generation on a fresh machine, I had issues with missing libvirt default network, and missing unzip for the macos bundle.
These 2 issues have been fixed in https://github.com/code-ready/snc/pull/503/commits , this PR backports these commits to the master branch