### PR TITLE
Revert "Use `latest` instead of `release` for butane"

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -35,7 +35,7 @@ ssh-keygen -t ecdsa -b 521 -N "" -f id_ecdsa_crc -C "core"
 ${YQ} eval --inplace ".passwd.users[0].ssh_authorized_keys[0] = \"$(cat id_ecdsa_crc.pub)\"" ${CRC_INSTALL_DIR}/fcos-config.yaml
 
 # Create the ign config 
-${PODMAN} run -i --rm quay.io/coreos/butane:latest --pretty --strict < ${CRC_INSTALL_DIR}/fcos-config.yaml > ${CRC_INSTALL_DIR}/fcos-config.ign
+${PODMAN} run -i --rm quay.io/coreos/butane:release --pretty --strict < ${CRC_INSTALL_DIR}/fcos-config.yaml > ${CRC_INSTALL_DIR}/fcos-config.ign
 
 # Validate ign config
 ${PODMAN} run --pull=always --rm -i quay.io/coreos/ignition-validate:release - < ${CRC_INSTALL_DIR}/fcos-config.ign


### PR DESCRIPTION
This reverts commit c4158a61870825086c5119dd67a37e7797779ed5.
There has been a 0.15.0 butane release with aarch64 payload, so we can
revert this commit as planned:
« When there's a new butane release, we can switch back to using
`release` instead of `latest` »