### PR TITLE
Use oc 4.10.x on macOS

### DIFF
--- a/snc-library.sh
+++ b/snc-library.sh
@@ -16,7 +16,8 @@ function download_oc() {
 
     if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then
         mkdir -p openshift-clients/mac
-        curl -L "${MIRROR}/${OPENSHIFT_RELEASE_VERSION}/openshift-client-mac-${OPENSHIFT_RELEASE_VERSION}.tar.gz" | tar -zx -C openshift-clients/mac oc
+        # workaround for https://github.com/code-ready/snc/issues/576
+        curl -L "${MIRROR}/stable-4.10/openshift-client-mac.tar.gz" | tar -zx -C openshift-clients/mac oc
     fi
     if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ]; then
         mkdir -p openshift-clients/windows


### PR DESCRIPTION
oc 4.11 does not work on macOS, and can cause "certificate is not
trusted" with `oc login` as indicated in OpenShift release notes
https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html

This commit temporarily switches back to oc 4.10 for macOS

This fixes https://github.com/code-ready/snc/issues/576