### PR TITLE
Revert "Workaround corrupted podman-remote-linux binaries"

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -276,7 +276,7 @@ function download_podman() {
     local arch=$2
 
     mkdir -p podman-remote/linux
-    curl -L https://github.com/containers/podman/releases/download/v4.1.1/podman-remote-static.tar.gz | tar -zx -C podman-remote/linux podman-remote-static
+    curl -L https://github.com/containers/podman/releases/download/v${version}/podman-remote-static.tar.gz | tar -zx -C podman-remote/linux podman-remote-static
     mv podman-remote/linux/podman-remote-static podman-remote/linux/podman-remote
     chmod +x podman-remote/linux/podman-remote
 


### PR DESCRIPTION
latest release of podman 4.1.1 and 4.2.0 have correct podman-remote binary so reverting this workaround.

This reverts commit 198c4b5e5df7bb93fbe6da3902a23d1106e82670.