### PR TITLE
createdisk-library: Use $@ instead $* for package list

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -161,7 +161,7 @@ function install_additional_packages() {
         # Download the hyperV daemons dependency on host
         local pkgDir=$(mktemp -d tmp-rpmXXX)
         mkdir -p ${pkgDir}/packages
-        sudo yum download --downloadonly --downloaddir ${pkgDir}/packages "$*" --resolve
+        sudo yum download --downloadonly --downloaddir ${pkgDir}/packages $* --resolve
 
         # SCP the downloaded rpms to VM
         ${SCP} -r ${pkgDir}/packages core@${vm_ip}:/home/core/


### PR DESCRIPTION
In shell $* interpreted as single word so when used with double quote
it make all the word as single one and package installation failed
as following if there is one than one package name.
```
+ install_additional_packages 192.168.13.11 hyperv-daemons cifs-utils
+ local IP=192.168.13.11
+ shift
++ mktemp -d tmp-rpmXXX
+ local pkgDir=tmp-rpmM5Z
+ mkdir -p tmp-rpmM5Z/packages
+ sudo yum download --downloadonly --downloaddir tmp-rpmM5Z/packages 'hyperv-daemons cifs-utils' --resolve
Updating Subscription Management repositories.
Last metadata expiration check: 0:10:30 ago on Friday 30 September 2022 05:48:16 AM UTC.
No package hyperv-daemons cifs-utils available.
Exiting due to strict setting.
Error: No package hyperv-daemons cifs-utils available.
```