### PR TITLE
Don't use  for hardcoded mac oc URL

### DIFF
--- a/snc-library.sh
+++ b/snc-library.sh
@@ -17,7 +17,7 @@ function download_oc() {
     if [ -n "${SNC_GENERATE_MACOS_BUNDLE}" ]; then
         mkdir -p openshift-clients/mac
         # workaround for https://github.com/code-ready/snc/issues/576
-        curl -L "${MIRROR}/stable-4.10/openshift-client-mac.tar.gz" | tar -zx -C openshift-clients/mac oc
+        curl -L "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.10/openshift-client-mac.tar.gz" | tar -zx -C openshift-clients/mac oc
     fi
     if [ -n "${SNC_GENERATE_WINDOWS_BUNDLE}" ]; then
         mkdir -p openshift-clients/windows


### PR DESCRIPTION
Because of https://github.com/code-ready/snc/issues/576 snc is
temporarily hardcoding the use of a 4.10 `oc` version.
However, the URL it's using depends on what `MIRROR` is set to. This can
be a problem if the mirror does not contain a /stable-4.10/ directory.
This commit hardcodes the full URL.
This fixes https://github.com/code-ready/snc/issues/585