### PR TITLE
Revert "Add cifs-utils package to hyperV bundle"

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -199,7 +199,7 @@ function prepare_cockpit() {
 function prepare_hyperV() {
     local vm_ip=$1
 
-    install_additional_packages ${vm_ip} hyperv-daemons cifs-utils
+    install_additional_packages ${vm_ip} hyperv-daemons
 
     # Adding Hyper-V vsock support
     ${SSH} core@${vm_ip} 'sudo bash -x -s' <<EOF


### PR DESCRIPTION
This reverts commit 73c7fa1c6ad6ac4e5b5ebaab640722a5e11290e5.

By default rhcos contains the cifs-utils package so no need to add it for hyperV bundle.
```
$ $ cat /etc/os-release
NAME="Red Hat Enterprise Linux CoreOS"
ID="rhcos"
ID_LIKE="rhel fedora"
VERSION="411.86.202208291737-0"
VERSION_ID="4.11"
PLATFORM_ID="platform:el8"
[...]

$ rpm -qa | grep cifs
cifs-utils-6.8-3.el8.x86_64
```