### PR TITLE
Add kernel-core and kernel-module package for RHEL-9 kernel update

### DIFF
--- a/createdisk-library.sh
+++ b/createdisk-library.sh
@@ -183,7 +183,7 @@ function install_rhel9_kernel {
     local pkgDir=$(mktemp -d tmp-rpmXXX)
 
     mkdir -p ${pkgDir}/packages
-    yum download --setopt=reposdir=./repos --setopt=sslcacert=./repos/2015-RH-IT-Root-CA.pem --downloadonly --downloaddir ${pkgDir}/packages kernel kernel-modules-extra --resolve
+    yum download --setopt=reposdir=./repos --setopt=sslcacert=./repos/2015-RH-IT-Root-CA.pem --downloadonly --downloaddir ${pkgDir}/packages kernel kernel-modules-extra kernel-core kernel-modules --resolve
     ${SCP} -r ${pkgDir}/packages core@${vm_ip}:/home/core/
     ${SSH} core@${vm_ip} -- 'SYSTEMD_OFFLINE=1 sudo -E rpm-ostree override replace /home/core/packages/*.rpm'
     ${SSH} core@${vm_ip} -- rm -fr /home/core/packages


### PR DESCRIPTION
This will fix following error
```
error: Could not depsolve transaction; 2 problems detected:
 Problem 1: conflicting requests
  - nothing provides kernel-core-uname-r = 5.14.0-70.30.1.el9_0.aarch64 needed by kernel-5.14.0-70.30.1.el9_0.aarch64
  - nothing provides kernel-modules-uname-r = 5.14.0-70.30.1.el9_0.aarch64 needed by kernel-5.14.0-70.30.1.el9_0.aarch64
 Problem 2: conflicting requests
  - nothing provides kernel-modules-uname-r = 5.14.0-70.30.1.el9_0.aarch64 needed by kernel-modules-extra-5.14.0-70.30.1.el9_0.aarch64
  - nothing provides kernel-uname-r = 5.14.0-70.30.1.el9_0.aarch64 needed by kernel-modules-extra-5.14.0-70.30.1.el9_0.aarch64
```