### PR TITLE
microshift: Add logic to create bundle of upcoming release

### DIFF
--- a/microshift.sh
+++ b/microshift.sh
@@ -66,7 +66,9 @@ function enable_repos {
 
 function download_microshift_rpm {
     local pkgDir=$1
-    if [ -n "${MICROSHIFT_NVR-}" ]; then
+    if [ -n "${MICROSHIFT_PRERELEASE-}" ]; then
+        sudo yum download --setopt=reposdir=./repos --downloadonly --downloaddir ${pkgDir} microshift microshift-networking microshift-release-info microshift-selinux microshift-greenboot
+    elif [ -n "${MICROSHIFT_NVR-}" ]; then
         sudo yum download --downloaddir ${pkgDir} --downloadonly microshift-${MICROSHIFT_NVR-} microshift-networking-${MICROSHIFT_NVR-} microshift-release-info-${MICROSHIFT_NVR-} microshift-selinux-${MICROSHIFT_NVR-} microshift-greenboot-${MICROSHIFT_NVR-}
     else
         sudo yum download --downloaddir ${pkgDir} --downloadonly microshift microshift-networking microshift-release-info microshift-selinux microshift-greenboot
@@ -76,7 +78,11 @@ function download_microshift_rpm {
 function create_iso {
     local pkgDir=$1
     rm -fr microshift
-    git clone -b release-4.13 https://github.com/openshift/microshift.git
+    if [ -n "${MICROSHIFT_PRERELEASE-}" ]; then
+       git clone -b main https://github.com/openshift/microshift.git
+    else
+       git clone -b release-4.13 https://github.com/openshift/microshift.git
+    fi
     cp podman_changes.ks microshift/
     pushd microshift
     sed -i '/# customizations/,$d' scripts/image-builder/config/blueprint_v0.0.1.toml

--- a/repos/mirror-microshift.repo
+++ b/repos/mirror-microshift.repo
@@ -1,0 +1,5 @@
+[mirror-microshift]
+name=microshift repo for mirror
+baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp-dev-preview/latest-4.14/elrhel-9/os/
+enabled=1
+gpgcheck=0


### PR DESCRIPTION
It uses `MICROSHIFT_PRERELEASE` as environment variable to create
bundle for upcoming release by getting the microshift-* rpms from
mirror.openshift.com