### PR TITLE
Enable swap on the node

### DIFF
--- a/99-kubelet-config.yaml
+++ b/99-kubelet-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: swap-config
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/master: ""
+  kubeletConfig:
+    failSwapOn: false 
+    memorySwap:
+      swapBehavior: UnlimitedSwap

--- a/99-openshift-machineconfig-master-swap-count.yaml
+++ b/99-openshift-machineconfig-master-swap-count.yaml
@@ -1,0 +1,12 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-kernel-swapcount-arg
+spec:
+  config:
+  ignition:
+    version: 3.4.0
+  kernelArguments:
+    - swapaccount=1

--- a/99-openshift-machineconfig-master-swap-service.yaml
+++ b/99-openshift-machineconfig-master-swap-service.yaml
@@ -1,0 +1,44 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-openshift-machineconfig-master-swap-service
+spec:
+  config:
+    ignition:
+      version: 3.4.0
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=Create 4GB swap partition
+          Before=var-crc-swapfile1.swap
+          
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          ExecStart=/usr/bin/mkdir -p /var/crc
+          ExecStart=/usr/bin/fallocate -l 4096m /var/crc/swapfile1
+          ExecStart=/usr/bin/chmod 600 /var/crc/swapfile1
+          ExecStart=/usr/sbin/mkswap /var/crc/swapfile1
+          
+          [Install]
+          WantedBy=multi-user.target
+        enabled: false
+        name: swap-partition.service
+      - contents: |
+          [Unit]
+          Description=Turn on the swap
+          
+          [Swap]
+          What=/var/crc/swapfile1
+          
+          [Install]
+          WantedBy=multi-user.target
+        enabled: false
+        name: var-crc-swapfile1.swap
+    networkd: {}
+    passwd: {}
+    storage: {}
+    osImageURL: ""

--- a/99_feature-gate.yaml
+++ b/99_feature-gate.yaml
@@ -1,0 +1,12 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  customNoUpgrade:
+    enabled:
+    - NodeSwap
+    - BuildCSIVolumes
+  featureSet: CustomNoUpgrade
+status:
+  featureGates: null

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -51,6 +51,9 @@ if [ ${BUNDLE_TYPE} != "microshift" ]; then
     
     # Stop the kubelet service so it will not reprovision the pods
     ${SSH} core@${VM_IP} -- sudo systemctl stop kubelet
+    # Enable swap partition and swap service
+    ${SSH} core@${VM_IP} -- sudo systemctl enable swap-partition.service
+    ${SSH} core@${VM_IP} -- sudo systemctl enable var-crc-swapfile1.swap
 fi
 
 # Enable the system and user level  podman.socket service for API V2

--- a/snc.sh
+++ b/snc.sh
@@ -31,7 +31,7 @@ BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
 CRC_PV_DIR="/mnt/pv-data"
 SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
 SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
-MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp-dev-preview}
+MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp}
 CERT_ROTATION=${SNC_DISABLE_CERT_ROTATION:-enabled}
 USE_PATCHED_RELEASE_IMAGE=${SNC_USE_PATCHED_RELEASE_IMAGE:-disabled}
 HTPASSWD_FILE='users.htpasswd'
@@ -44,7 +44,7 @@ if test -n "${OPENSHIFT_VERSION-}"; then
     OPENSHIFT_RELEASE_VERSION=${OPENSHIFT_VERSION}
     echo "Using release ${OPENSHIFT_RELEASE_VERSION} from OPENSHIFT_VERSION"
 else
-    OPENSHIFT_RELEASE_VERSION="$(curl -L "${MIRROR}"/candidate-4.15/release.txt | sed -n 's/^ *Version: *//p')"
+    OPENSHIFT_RELEASE_VERSION="$(curl -L "${MIRROR}"/latest-4.15/release.txt | sed -n 's/^ *Version: *//p')"
     if test -n "${OPENSHIFT_RELEASE_VERSION}"; then
         echo "Using release ${OPENSHIFT_RELEASE_VERSION} from the latest mirror"
     else

--- a/snc.sh
+++ b/snc.sh
@@ -26,7 +26,7 @@ INSTALL_DIR=crc-tmp-install-data
 SNC_PRODUCT_NAME=${SNC_PRODUCT_NAME:-crc}
 SNC_CLUSTER_MEMORY=${SNC_CLUSTER_MEMORY:-14336}
 SNC_CLUSTER_CPUS=${SNC_CLUSTER_CPUS:-6}
-CRC_VM_DISK_SIZE=${CRC_VM_DISK_SIZE:-31}
+CRC_VM_DISK_SIZE=${CRC_VM_DISK_SIZE:-35}
 BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
 CRC_PV_DIR="/mnt/pv-data"
 SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
@@ -147,6 +147,11 @@ cp cluster-network-03-config.yaml ${INSTALL_DIR}/manifests/
 cp 99_master-chronyd-mask.yaml $INSTALL_DIR/openshift/
 # Add dummy network unit file
 cp 99-openshift-machineconfig-master-dummy-networks.yaml $INSTALL_DIR/openshift/
+cp 99-openshift-machineconfig-master-swap-count.yaml $INSTALL_DIR/openshift/
+cp 99-openshift-machineconfig-master-swap-service.yaml $INSTALL_DIR/openshift/
+cp 99-kubelet-config.yaml $INSTALL_DIR/openshift/
+cp 99_feature-gate.yaml $INSTALL_DIR/openshift/
+
 # Add kubelet config resource to make change in kubelet
 DYNAMIC_DATA=$(base64 -w0 node-sizing-enabled.env) envsubst < 99_master-node-sizing-enabled-env.yaml.in > $INSTALL_DIR/openshift/99_master-node-sizing-enabled-env.yaml
 # Add codeReadyContainer as invoker to identify it with telemeter


### PR DESCRIPTION
After switching to OVN-K we observed increase in memory resource and one
way to tackle it to have swap enabled on the node.

This PR is try to do following.
- Enable only `NodeSwap` feature gate instead complete Tech preview
  features.
     - https://docs.openshift.com/container-platform/4.15/rest_api/config_apis/featuregate-config-openshift-io-v1.html
- Add `swapaccount=1` to kernel argument which is required for the swap
    - https://docs.openshift.com/container-platform/4.15/nodes/nodes/nodes-nodes-managing.html#nodes-nodes-swap-memory_nodes-nodes-managing
- Add swap feature to kubelet config
- Add systemd unit file to create swap and enable it
- Extend the disk size by 4GB because that much of space used for swap