### PR TITLE
Check for openshift-install version

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -68,9 +68,11 @@ echo "Setting OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE to ${OPENSHIFT_INSTALL_RE
 
 # Extract openshift-install binary if not present in current directory
 if test -z ${OPENSHIFT_INSTALL-}; then
-    echo "Extracting OpenShift installer binary"
-    ${OC} adm release extract -a ${OPENSHIFT_PULL_SECRET_PATH} ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} --command=openshift-install --to .
     OPENSHIFT_INSTALL=./openshift-install
+    if [[ ! -f "$OPENSHIFT_INSTALL" || $("$OPENSHIFT_INSTALL" version | grep -oP "${OPENSHIFT_INSTALL} \\K\\S+") != "$OPENSHIFT_VERSION" ]]; then
+        echo "Extracting OpenShift installer binary"
+        ${OC} adm release extract -a ${OPENSHIFT_PULL_SECRET_PATH} ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} --command=openshift-install --to .
+    fi
 fi
 
 if [[ ${USE_PATCHED_RELEASE_IMAGE} == "enabled" ]]


### PR DESCRIPTION
The `oc adm release extract` command is also quite time consuming when running multiple times. So introduce a check to see if we even need to get the openshift-install binary.

I think checking the version of the binary is probably a good idea to do in any case, so this could be further improved upon by dropping the -z test, and do something like

```shell
if [[ ! -f "${OPENSHIFT_INSTALL:=./openshift-install}" ... ]]; then
```
(If it's provided verify the file exists AND the version is what we're expecting.) I could make the code move the extracted binary to the path provided by OPENSHIFT_INSTALL in that case.

## Summary by Sourcery

Enhancements:
- Add existence and version check for the openshift-install binary and only extract when missing or outdated