### PR TITLE
add start condition to few post-start services

### DIFF
--- a/systemd/crc-pullsecret.service
+++ b/systemd/crc-pullsecret.service
@@ -3,6 +3,7 @@ Description=CRC Unit for adding pull secret to cluster
 After=crc-wait-apiserver-up.service
 StartLimitIntervalSec=450
 StartLimitBurst=10
+ConditionPathExists=!/opt/crc/%n.done
 
 [Service]
 Type=oneshot
@@ -10,6 +11,7 @@ Restart=on-failure
 RestartSec=40
 ExecCondition=/usr/local/bin/crc-check-cloud-env.sh
 ExecStart=/usr/local/bin/crc-pullsecret.sh
+ExecStartPost=-touch /opt/crc/%n.done
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/ocp-cluster-ca.service
+++ b/systemd/ocp-cluster-ca.service
@@ -3,6 +3,7 @@ Description=CRC Unit setting custom cluster ca
 After=crc-wait-apiserver-up.service
 StartLimitIntervalSec=450
 StartLimitBurst=10
+ConditionPathExists=!/opt/crc/%n.done
 
 [Service]
 Type=oneshot
@@ -10,6 +11,7 @@ Restart=on-failure
 RestartSec=40
 ExecCondition=/usr/local/bin/crc-check-cloud-env.sh
 ExecStart=/usr/local/bin/ocp-cluster-ca.sh
+ExecStartPost=-touch /opt/crc/%n.done
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/ocp-custom-domain.service
+++ b/systemd/ocp-custom-domain.service
@@ -3,6 +3,7 @@ Description=CRC Unit setting nip.io domain for cluster
 After=crc-wait-apiserver-up.service
 StartLimitIntervalSec=450
 StartLimitBurst=10
+ConditionPathExists=!/opt/crc/%n.done
 
 [Service]
 Type=oneshot
@@ -11,6 +12,7 @@ RestartSec=40
 EnvironmentFile=-/etc/sysconfig/crc-env
 ExecCondition=/usr/local/bin/crc-check-cloud-env.sh
 ExecStart=/usr/local/bin/ocp-custom-domain.sh
+ExecStartPost=-touch /opt/crc/%n.done
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/ocp-userpasswords.service
+++ b/systemd/ocp-userpasswords.service
@@ -4,6 +4,7 @@ Before=ocp-cluster-ca.service
 After=crc-wait-apiserver-up.service
 StartLimitIntervalSec=450
 StartLimitBurst=10
+ConditionPathExists=!/opt/crc/%n.done
 
 [Service]
 Type=oneshot
@@ -12,6 +13,7 @@ RestartSec=40
 ExecCondition=/usr/local/bin/crc-check-cloud-env.sh
 ExecStartPre=/usr/bin/sleep 5
 ExecStart=/usr/local/bin/ocp-userpasswords.sh
+ExecStartPost=-touch /opt/crc/%n.done
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
this adds a FileExists condition to the services setting up cluster-ca, custom-domain, adding pull-secret and passwords for developer and kubeadmin users

the marker file is created by the services in ExecStartPost and prevents the services from running again after a reboot as the needed mofications were applied in the first boot

fixes #1081


## Summary by Sourcery

Add marker-file based start conditions to post-start systemd services to ensure they run only once and prevent redundant execution on reboot

Enhancements:
- Add FileExists start condition to cluster-ca, custom-domain, pull-secret, and user-passwords services
- Generate marker files in ExecStartPost to flag completion and skip subsequent runs on reboot