### PR TITLE
microshift: Use 4.20 version since ec now available

### DIFF
--- a/microshift.sh
+++ b/microshift.sh
@@ -16,7 +16,7 @@ SNC_CLUSTER_CPUS=${SNC_CLUSTER_CPUS:-2}
 CRC_VM_DISK_SIZE=${CRC_VM_DISK_SIZE:-31}
 BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
 MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp-dev-preview}
-MICROSHIFT_VERSION=${MICROSHIFT_VERSION:-4.19}
+MICROSHIFT_VERSION=${MICROSHIFT_VERSION:-4.20}
 MIRROR_REPO=${MIRROR_REPO:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/microshift/ocp-dev-preview/latest-${MICROSHIFT_VERSION}/el9/os}
 
 echo "Check if system is registered"

--- a/repos/mirror-microshift.repo
+++ b/repos/mirror-microshift.repo
@@ -1,5 +1,5 @@
 [mirror-microshift]
 name=microshift repo for mirror
-baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp-dev-preview/latest-4.19/el9/os/
+baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp-dev-preview/latest-4.20/el9/os/
 enabled=1
 gpgcheck=0


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Bump default MicroShift version to 4.20 and update mirror repository URL to reference the 4.20 path