### PR TITLE
Preload aws-cli container image

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -18,6 +18,7 @@ BASE_DOMAIN=$(${JQ} -r .clusterInfo.baseDomain $INSTALL_DIR/crc-bundle-info.json
 BUNDLE_TYPE=$(${JQ} -r .type $INSTALL_DIR/crc-bundle-info.json)
 ADDITIONAL_PACKAGES="cloud-init gvisor-tap-vsock-gvforwarder"
 PRE_DOWNLOADED_ADDITIONAL_PACKAGES=""
+AWSCLI_VERSION=2.28.1
 
 case ${BUNDLE_TYPE} in
     microshift)
@@ -134,6 +135,9 @@ ${SSH} core@${VM_IP} -- "sudo podman pull quay.io/crcont/routes-controller:${ima
 TAG=${image_tag} envsubst < routes-controller.yaml.in > $INSTALL_DIR/routes-controller.yaml
 ${SCP} $INSTALL_DIR/routes-controller.yaml core@${VM_IP}:/home/core/
 ${SSH} core@${VM_IP} -- 'sudo mkdir -p /opt/crc && sudo mv /home/core/routes-controller.yaml /opt/crc/'
+
+# Preload aws-cli image
+${SSH} core@${VM_IP} -- "sudo podman pull docker.io/amazon/aws-cli:${AWSCLI_VERSION}"
 
 if [ ${BUNDLE_TYPE} != "microshift" ]; then
     # Add internalIP as node IP for kubelet systemd unit file


### PR DESCRIPTION
this is needed when running the bundle on aws in
self sufficient mode, the awscli is used to  get
the pull-secret from the AWS SSM service

having this image available removes the need  to
download and extract the binary from the relased
zip whiches increases the bundle start time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Preloaded the AWS CLI container image on the VM to streamline setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->