### PR TITLE
workaround self sufficient check for crc

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -170,6 +170,16 @@ fi
 install_additional_packages ${VM_IP}
 copy_systemd_units
 
+# Create marker file with default value expected by systemd units
+# CRC_SELF_SUFFICIENT=0 to ensure bundle works with CRC without a
+# cloud-init configuration
+${SSH} core@${VM_IP} 'sudo bash -x -s' <<EOF
+  tee /etc/sysconfig/crc-env <<TEE
+CRC_SELF_SUFFICIENT=0
+TEE
+EOF
+
+
 cleanup_vm_image ${VM_NAME} ${VM_IP}
 
 # Enable cloud-init service


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * During VM initialization, create a default marker file that sets the CRC self-sufficiency flag to "off" (CRC_SELF_SUFFICIENT=0).
  * The marker is written remotely late in the setup sequence after package installation and unit copying, before image cleanup.
  * No other initialization behavior or control flow is changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->