### PR TITLE
[release-4.20] 9p: add 9p fuse client

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -166,7 +166,17 @@ EOF
    PRE_DOWNLOADED_ADDITIONAL_PACKAGES+=" qemu-user-static-x86"
 fi
 
-# Beyond this point, packages added to the ADDITIONAL_PACKAGES variable won’t be installed in the guest
+# install 9pfs binary from COPR repo so that it can be used to
+# set up 9p file sharing on Windows
+if [ "${SNC_GENERATE_WINDOWS_BUNDLE}" != "0" ]; then
+    ${SSH} core@${VM_IP} -- "sudo dnf -y copr enable mskvarla/9pfs"
+    ${SSH} core@${VM_IP} -- "mkdir -p ~/packages && dnf download --downloadonly --downloaddir ~/packages 9pfs --resolve"
+    ${SSH} core@${VM_IP} -- "sudo dnf -y copr disable mskvarla/9pfs"
+    PRE_DOWNLOADED_ADDITIONAL_PACKAGES+=" 9pfs"
+fi
+
+# Beyond this point, packages added to the ADDITIONAL_PACKAGES and PRE_DOWNLOADED_ADDITIONAL_PACKAGES
+# variables won’t be installed in the guest
 install_additional_packages ${VM_IP}
 copy_systemd_units
 


### PR DESCRIPTION
Rebased #1123 for release 4.20.

9P support for filesharing on Windows: https://github.com/crc-org/crc/issues/4168

This adds the necessary steps for installation of the 9pfs client to the hyperv image. The binary is installed from a COPR repository. This binary is needed to enable 9P file sharing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 9P filesystem support for Windows guest provisioning, enabling improved file sharing capabilities.

* **Improvements**
  * Enhanced package management during disk provisioning to handle both standard and pre-downloaded packages more comprehensively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->