### PR TITLE
Use /tmp/kubeconfig to avoid modifying /opt/kubeconfig

### DIFF
--- a/systemd/crc-cluster-status.sh
+++ b/systemd/crc-cluster-status.sh
@@ -30,6 +30,7 @@ try_login() {
         set +x
         set +e # don't abort on error in this subshell
         oc login --insecure-skip-tls-verify=true \
+	   --kubeconfig=/tmp/kubeconfig \
            -u kubeadmin \
            -p "$(cat /opt/crc/pass_kubeadmin)" \
            https://api.crc.testing:6443 > /dev/null 2>&1


### PR DESCRIPTION
Currently, the crc-cluster-status.sh script logs into OpenShift using the kubeadmin account, which writes authentication tokens to the default kubeconfig file at /opt/kubeconfig. This results in kubeadmin token entries adding to the system:admin kubeconfig file, where the tokens eventually expire and may cause authentication or usability issues for system administrators.

This PR use --kubeconfig=/tmp/kubeconfig to avoid modifying the /opt/kubeocnfig file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cluster authentication configuration to use an explicit kubeconfig path during login operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->