### PR TITLE
bump kubevirt-hostpath csi driver image tag to v4.20

### DIFF
--- a/kubevirt-hostpath-provisioner-csi/csi-driver/kustomization.yaml
+++ b/kubevirt-hostpath-provisioner-csi/csi-driver/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 images:
   - name: quay.io/kubevirt/hostpath-csi-driver
     newName: registry.redhat.io/container-native-virtualization/hostpath-csi-driver-rhel9
-    newTag: v4.15
+    newTag: v4.20
   - name: registry.k8s.io/sig-storage/csi-node-driver-registrar
     newName: registry.redhat.io/openshift4/ose-csi-node-driver-registrar
     newTag: latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated hostpath CSI driver component to version 4.20.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->