### PR TITLE
Remove `download_podman` and related code

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ export BUNDLED_PULL_SECRET_PATH="/tmp/pull_secret.json"
 After running snc.sh/createdisk.sh, the generated bundles can be uploaded to a container registry using this command:
 
 ```
-./gen-bundle-image.sh <version> <openshift/okd/podman>
+./gen-bundle-image.sh <version> <openshift/okd/microshift>
 ```
 
 Note: a GPG key is needed to sign the bundles before they are wrapped in a container image.

--- a/crc-bundle-info.json.sample
+++ b/crc-bundle-info.json.sample
@@ -78,7 +78,7 @@
       {
         # Name of the file
 	"name": "oc"
-	# What kind of file this is, valid types are 'oc-executable', 'podman-executable'
+	# What kind of file this is, valid types are 'oc-executable'
 	"type": "oc-executable"
 	"size": "72728632"
 	"sha256sum": "983f0883a6dffd601afa663d10161bfd8033fd6d45cf587a9cb22e9a681d6047"

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -210,8 +210,6 @@ EOF
     ${SSH} core@${VM_IP} -- "sudo podman stop crc-etcd"
 fi
 
-podman_version=$(${SSH} core@${VM_IP} -- 'rpm -q --qf %{version} podman')
-
 # Disable cloud-init network config
 ${SSH} core@${VM_IP} 'sudo bash -x -s' << EOF
 cat << EFF > /etc/cloud/cloud.cfg.d/05_disable-network.cfg
@@ -239,9 +237,6 @@ ${SSH} core@${VM_IP} -- "sudo cloud-init clean --logs"
 
 # Shutdown the VM
 shutdown_vm ${VM_NAME}
-
-# Download podman clients
-download_podman $podman_version ${yq_ARCH}
 
 # libvirt image generation
 get_dest_dir_suffix "${OPENSHIFT_VERSION}"

--- a/gen-bundle-image.sh
+++ b/gen-bundle-image.sh
@@ -82,7 +82,7 @@ function sign_bundle_files {
 }
 
 if [[ $# -ne 2 ]]; then
-   echo "You need to provide the bundle version and preset (openshift/podman/okd/microshift)"
+   echo "You need to provide the bundle version and preset (openshift/okd/microshift)"
    exit 1
 fi
 


### PR DESCRIPTION
Fixes #1195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bundle generation command references to reflect supported platforms.

* **Refactor**
  * Removed Podman support from the bundle creation process.
  * Simplified bundle generation by eliminating Podman client downloads and configuration steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->