### PR TITLE
systemd: Use admin user and context instead system:admin

### DIFF
--- a/systemd/ocp-cluster-ca.sh
+++ b/systemd/ocp-cluster-ca.sh
@@ -83,14 +83,14 @@ fi
 export KUBECONFIG=/opt/crc/kubeconfig
 rm -rf "$KUBECONFIG"
 
-oc config set-credentials system:admin \
+oc config set-credentials admin \
    --client-certificate="$CLIENT_CA_FILE_PATH" \
    --client-key="$CLIENT_CA_KEY_FILE_PATH" \
    --embed-certs
 
-oc config set-context system:admin --cluster="$cluster_name" --namespace=default --user=system:admin
+oc config set-context admin --cluster="$cluster_name" --namespace=default --user=admin
 oc config set-cluster "$cluster_name" --server="$apiserver_url" --insecure-skip-tls-verify=true
-oc config use-context system:admin
+oc config use-context admin
 
 wait_for_resource_or_die clusteroperators 90 2
 


### PR DESCRIPTION
kubeconfig which is generated by installer have admin user and admin context but the kubeconfig file we generate have `system:admin` which makes restart fail on crc side because in crc codebase we are using `admin` context so instead of modify code in crc, it would be better to change here.
```
$ oc config get-contexts --kubeconfig=/home/prkumar/.crc/cache/crc_libvirt_4.20.5_amd64/kubeconfig
CURRENT   NAME    CLUSTER   AUTHINFO   NAMESPACE
*         admin   crc       admin

```

With our changes modified kubeconfig file
```
[core@crc ~]$ oc config get-contexts --kubeconfig=/opt/kubeconfig
CURRENT   NAME           CLUSTER   AUTHINFO       NAMESPACE
*         system:admin   crc       system:admin   default
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cluster configuration user and context references for consistency and clarity. Credentials and authentication settings now use standardized naming conventions while maintaining full functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->