### PR TITLE
Install qemu-user-static from newer fedora release

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -157,7 +157,7 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&ar
 enabled=1
 type=rpm
 repo_gpgcheck=0
-gpgcheck=0
+gpgcheck=1
 EOF
    ${SCP} /tmp/fedora-updates.repo core@${VM_IP}:/tmp
    ${SSH} core@${VM_IP} -- "sudo mv /tmp/fedora-updates.repo /etc/yum.repos.d"

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -152,8 +152,8 @@ if [ "${ARCH}" == "aarch64" ] && [ ${BUNDLE_TYPE} != "okd" ]; then
    # in any subscription repo.
    cat > /tmp/fedora-updates.repo <<'EOF'
 [fedora-updates]
-name=Fedora 41 - $basearch - Updates
-metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f41&arch=$basearch
+name=Fedora 44 - $basearch - Updates
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&arch=$basearch
 enabled=1
 type=rpm
 repo_gpgcheck=0

--- a/image-mode/microshift/config/Containerfile.bootc-rhel9
+++ b/image-mode/microshift/config/Containerfile.bootc-rhel9
@@ -12,7 +12,7 @@ RUN if [ -z "${UNRELEASED_MIRROR_REPO}" ]; then \
       dnf config-manager --add-repo "${UNRELEASED_MIRROR_REPO}" \
           --add-repo "https://mirror.openshift.com/pub/openshift-v4/$(uname -m)/dependencies/rpms/${MICROSHIFT_VER}-el9-beta" \
           --set-enabled "fast-datapath-for-rhel-9-$(uname -m)-rpms"; \
-      dnf config-manager --save --setopt="${repoID}".gpgcheck=0 --setopt=*-el9-beta.gpgcheck=0; \
+      dnf config-manager --save --setopt="${repoID}".gpgcheck=1 --setopt=*-el9-beta.gpgcheck=1; \
     fi
 RUN dnf install -y firewalld microshift microshift-release-info cloud-utils-growpart qemu-guest-agent dnsmasq && \
     dnf clean all && rm -fr /etc/yum.repos.d/*

--- a/repos/mirror-microshift.repo
+++ b/repos/mirror-microshift.repo
@@ -2,4 +2,4 @@
 name=microshift repo for mirror
 baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/microshift/ocp-dev-preview/latest-4.20/el9/os/
 enabled=1
-gpgcheck=0
+gpgcheck=1


### PR DESCRIPTION
This PR gets qemu-user-static from fedora 44 instead of using the out of support f41.
Maybe we should consider getting qemu-user-static from centos if it’s built there.

This PR also attempts to enable gpgcheck on yum repos, but I expect it will take a few tries to get it to work (if at all).


- **Install qemu-user-static from fedora 44**
- **Enable gpgcheck on yum repos**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced package signature verification by enabling GPG checks across repository configurations

* **Chores**
  * Updated Fedora repository targeting from version 41 to version 44

<!-- end of auto-generated comment: release notes by coderabbit.ai -->