### PR TITLE
ovs-configuration: Reduce retry interval from 15m to 30s

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -4,20 +4,6 @@ set -exuo pipefail
 
 sudo yum install -y podman make golang rsync
 
-cat > /tmp/ignoretests.txt << EOF
-[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance] [Suite:openshift/conformance/serial/minimal] [Suite:k8s]
-[sig-cli] Kubectl client Kubectl cluster-info should check if Kubernetes control plane services is included in cluster-info  [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]
-[sig-scheduling] SchedulerPreemption [Serial] validates basic preemption works [Conformance] [Suite:openshift/conformance/serial/minimal] [Suite:k8s]
-[sig-scheduling] SchedulerPreemption [Serial] validates lower priority pod preemption by critical pod [Conformance] [Suite:openshift/conformance/serial/minimal] [Suite:k8s]
-[k8s.io] [sig-node] NoExecuteTaintManager Multiple Pods [Serial] evicts pods with minTolerationSeconds [Disruptive] [Conformance] [Suite:k8s]
-[k8s.io] [sig-node] NoExecuteTaintManager Single Pod [Serial] removing taint cancels eviction [Disruptive] [Conformance] [Suite:k8s]
-[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should mutate custom resource with pruning [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]
-[sig-api-machinery] AdmissionWebhook [Privileged:ClusterAdmin] should mutate pod and apply defaults after mutation [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]
-[sig-api-machinery] Aggregator Should be able to support the 1.17 Sample API Server using the current Aggregator [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]
-[sig-apps] Daemon set [Serial] should rollback without unnecessary restarts [Conformance] [Skipped:SingleReplicaTopology] [Suite:openshift/conformance/serial/minimal] [Suite:k8s]
-[sig-network] Proxy version v1 A set of valid responses are returned for both pod and service ProxyWithPath [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]
-EOF
-
 ./shellcheck.sh
 ./snc.sh
 
@@ -68,7 +54,7 @@ crc start --disk-size 80 -m 24000 -c 10 -p "${HOME}"/pull-secret --log-level deb
 
 mkdir -p crc-tmp-install-data/test-artifacts
 export KUBECONFIG="${HOME}"/.crc/machines/crc/kubeconfig
-openshift-tests run kubernetes/conformance --dry-run | grep -F -v -f /tmp/ignoretests.txt | openshift-tests run -o crc-tmp-install-data/test-artifacts/e2e.log --junit-dir crc-tmp-install-data/test-artifacts/junit --disable-monitor alert-summary-serializer,metrics-endpoints-down,metrics-api-availability,monitoring-statefulsets-recreation,pod-network-avalibility,legacy-test-framework-invariants,api-unreachable-from-client-metrics,clusteroperator-collector -f -
+openshift-tests run kubernetes/conformance/parallel/minimal --monitor pod-lifecycle -o crc-tmp-install-data/test-artifacts/e2e.log --junit-dir crc-tmp-install-data/test-artifacts/junit
 rc=$?
 echo "${rc}" > /tmp/test-return
 set -e

--- a/systemd/ovs-configuration.service.d/crc-retry-override.conf
+++ b/systemd/ovs-configuration.service.d/crc-retry-override.conf
@@ -1,0 +1,5 @@
+[Service]
+# CRC: Override retry interval for transient startup races
+# Default is 15m which is too long for intermittent failures
+# Use 30s for faster recovery without overwhelming the system
+Environment="RETRY=30s"


### PR DESCRIPTION
The configure-ovs.sh script has a 15-minute retry interval when it encounters transient failures during startup. This is too long and causes crc start to appear hung.

Override RETRY to 30s to handle intermittent race conditions faster without overwhelming the system with tight retry loops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shortened OVS configuration service retry interval to improve startup retry responsiveness for transient issues.

* **Tests**
  * CI now runs a fixed minimal conformance test suite directly, removing prior dry-run and filtered selection steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #1219 