### PR TITLE
superseed #1216

### DIFF
--- a/createdisk.sh
+++ b/createdisk.sh
@@ -157,7 +157,7 @@ metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&ar
 enabled=1
 type=rpm
 repo_gpgcheck=0
-gpgcheck=0
+gpgcheck=1
 EOF
    ${SCP} /tmp/fedora-updates.repo core@${VM_IP}:/tmp
    ${SSH} core@${VM_IP} -- "sudo mv /tmp/fedora-updates.repo /etc/yum.repos.d"

--- a/createdisk.sh
+++ b/createdisk.sh
@@ -152,8 +152,8 @@ if [ "${ARCH}" == "aarch64" ] && [ ${BUNDLE_TYPE} != "okd" ]; then
    # in any subscription repo.
    cat > /tmp/fedora-updates.repo <<'EOF'
 [fedora-updates]
-name=Fedora 41 - $basearch - Updates
-metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f41&arch=$basearch
+name=Fedora 44 - $basearch - Updates
+metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f44&arch=$basearch
 enabled=1
 type=rpm
 repo_gpgcheck=0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated temporary Fedora updates repository from Fedora 41 to Fedora 44 for aarch64 builds.
  * Enabled GPG package signature verification for that repository.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crc-org/snc/pull/1223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->