### PR TITLE
Use ocp/candidate-4.21 for 4.21 branch

### DIFF
--- a/ci_microshift.sh
+++ b/ci_microshift.sh
@@ -5,7 +5,7 @@ set -exuo pipefail
 sudo yum install -y make golang
 
 ./shellcheck.sh
-MICROSHIFT_PRERELEASE=yes ./microshift.sh
+./microshift.sh
 
 # Set the zstd compression level to 10 to have faster
 # compression while keeping a reasonable bundle size.

--- a/snc.sh
+++ b/snc.sh
@@ -31,7 +31,7 @@ BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
 CRC_PV_DIR="/mnt/pv-data"
 SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
 SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
-MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp-dev-preview}
+MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp}
 CERT_ROTATION=${SNC_DISABLE_CERT_ROTATION:-enabled}
 USE_PATCHED_RELEASE_IMAGE=${SNC_USE_PATCHED_RELEASE_IMAGE:-disabled}
 HTPASSWD_FILE='users.htpasswd'
@@ -44,7 +44,7 @@ if test -n "${OPENSHIFT_VERSION-}"; then
     OPENSHIFT_RELEASE_VERSION=${OPENSHIFT_VERSION}
     echo "Using release ${OPENSHIFT_RELEASE_VERSION} from OPENSHIFT_VERSION"
 else
-    OPENSHIFT_RELEASE_VERSION="$(curl -L "${MIRROR}"/candidate/release.txt | sed -n 's/^ *Version: *//p')"
+    OPENSHIFT_RELEASE_VERSION="$(curl -L "${MIRROR}"/candidate-4.21/release.txt | sed -n 's/^ *Version: *//p')"
     if test -n "${OPENSHIFT_RELEASE_VERSION}"; then
         echo "Using release ${OPENSHIFT_RELEASE_VERSION} from the latest mirror"
     else


### PR DESCRIPTION
Since 4.21 is released and ocp-dev-preview only provide payload for non released version so better to use that. Also remove microshift pre release flag from ci script since that is also released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline configuration for release builds
  * Modified release version resolution to use stable mirror sources instead of development paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->