### PR TITLE
[release 4.21] Check libvirt service 

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -2,7 +2,7 @@
 
 set -exuo pipefail
 
-sudo yum install -y podman make golang rsync
+sudo yum install -y git-core virtiofsd podman make golang rsync
 
 ./shellcheck.sh
 ./snc.sh

--- a/ci.sh
+++ b/ci.sh
@@ -9,6 +9,7 @@ sudo yum install -y git-core virtiofsd podman make golang rsync
 
 echo "### Extracting openshift-tests binary"
 mkdir /tmp/os-test
+sudo cp ./openshift-clients/linux/oc /usr/local/bin/
 export TESTS_IMAGE=$(oc --kubeconfig=crc-tmp-install-data/auth/kubeconfig adm release info -a "${HOME}"/pull-secret --image-for=tests)
 oc image extract -a "${HOME}"/pull-secret "${TESTS_IMAGE}" --path=/usr/bin/openshift-tests:/tmp/os-test/.
 chmod +x /tmp/os-test/openshift-tests

--- a/ci.sh
+++ b/ci.sh
@@ -10,6 +10,9 @@ sudo yum install -y git-core virtiofsd podman make golang rsync
 echo "### Extracting openshift-tests binary"
 mkdir /tmp/os-test
 sudo cp ./openshift-clients/linux/oc /usr/local/bin/
+# openshift-tests binary uses kubelet command to run test because some of those
+# tests comes from upstream
+sudo ln -s /usr/local/bin/oc /usr/local/bin/kubectl
 export TESTS_IMAGE=$(oc --kubeconfig=crc-tmp-install-data/auth/kubeconfig adm release info -a "${HOME}"/pull-secret --image-for=tests)
 oc image extract -a "${HOME}"/pull-secret "${TESTS_IMAGE}" --path=/usr/bin/openshift-tests:/tmp/os-test/.
 chmod +x /tmp/os-test/openshift-tests

--- a/ci_microshift.sh
+++ b/ci_microshift.sh
@@ -2,7 +2,7 @@
 
 set -exuo pipefail
 
-sudo yum install -y git-core virtiofsd make golang
+sudo yum install -y git-core virtiofsd podman make golang
 
 ./shellcheck.sh
 ./microshift.sh

--- a/ci_microshift.sh
+++ b/ci_microshift.sh
@@ -2,7 +2,7 @@
 
 set -exuo pipefail
 
-sudo yum install -y make golang
+sudo yum install -y git-core virtiofsd make golang
 
 ./shellcheck.sh
 ./microshift.sh

--- a/microshift.sh
+++ b/microshift.sh
@@ -15,7 +15,7 @@ SNC_CLUSTER_MEMORY=${SNC_CLUSTER_MEMORY:-2048}
 SNC_CLUSTER_CPUS=${SNC_CLUSTER_CPUS:-2}
 CRC_VM_DISK_SIZE=${CRC_VM_DISK_SIZE:-31}
 BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
-MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp-dev-preview}
+MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp}
 MICROSHIFT_VERSION=${MICROSHIFT_VERSION:-4.21}
 MIRROR_REPO=${MIRROR_REPO:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/microshift/ocp-dev-preview/latest-${MICROSHIFT_VERSION}/el9/os}
 

--- a/snc-library.sh
+++ b/snc-library.sh
@@ -59,6 +59,7 @@ function run_preflight_checks() {
         fi
 
         echo "Checking libvirt and DNS configuration"
+	check_libvirt_service
 
 	LIBVIRT_URI=qemu:///system
         # check if we can connect to ${LIBVIRT_URI}

--- a/tools.sh
+++ b/tools.sh
@@ -107,6 +107,16 @@ if ! which ${PATCH}; then
     sudo yum -y install /usr/bin/patch
 fi
 
+function check_libvirt_service {
+    if ! grep -qE "^(ID=|ID_LIKE=).*(rhel|fedora|centos)" /etc/os-release 2>/dev/null; then
+        echo "Skipping libvirt service check for non-RHEL/Fedora/CentOS system"
+        return
+    fi
+    # https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/configuring_and_managing_virtualization/assembly_enabling-virtualization-in-rhel-9_configuring-and-managing-virtualization#proc_enabling-virtualization-in-rhel-9_assembly_enabling-virtualization-in-rhel-9
+    # only start the required socket for virsh to work
+    for drv in qemu network secret storage; do sudo systemctl start virt${drv}d{,-ro,-admin}.socket; done
+}
+
 function retry {
     # total wait time = 2 ^ (retries - 1) - 1 seconds
     local retries=14


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now installs additional system packages (git, virtiofsd, podman, make, golang, rsync) during setup.
  * Added a host libvirt service check and automatic start of required libvirt sockets on applicable OS families; preflight now runs this extra libvirt validation.
  * Default OpenShift client mirror URL updated to the primary mirror.
* **Bug Fixes**
  * Test image lookup and extraction now use the bundled client with the configured kubeconfig instead of relying on PATH, improving reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crc-org/snc/pull/1227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->