### PR TITLE
snc: Replace custom OS image with transient-ro for /Users directory 

### DIFF
--- a/99-enable-transient-ro.yaml
+++ b/99-enable-transient-ro.yaml
@@ -1,0 +1,47 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-enable-transient-ro
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+      - name: enable-transient-ro.service
+        enabled: true
+        contents: |
+          [Unit]
+          Description=Enable transient-ro in ostree prepare-root config
+          ConditionPathExists=!/var/lib/transient-ro-configured
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          ExecStart=/bin/rpm-ostree usroverlay
+          ExecStart=/bin/bash -c 'sed -i "s/enabled = maybe/enabled = yes/" /usr/lib/ostree/prepare-root.conf'
+          ExecStart=/bin/bash -c 'echo -e "\\n[root]\\ntransient-ro = true" >> /usr/lib/ostree/prepare-root.conf'
+          ExecStart=/bin/mount -o remount,rw /boot
+          ExecStart=/bin/bash -c 'dracut -f $(grep -h initrd /boot/loader/entries/*.conf | awk "{print \\$2}") $(uname -r)'
+          ExecStart=/bin/mkdir -p /var/Users
+          ExecStartPost=/bin/touch /var/lib/transient-ro-configured
+
+          [Install]
+          WantedBy=multi-user.target
+      - name: create-users-mount.service
+        enabled: true
+        contents: |
+          [Unit]
+          Description=Create /Users mountpoint using transient-ro
+          After=local-fs-pre.target
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          ExecStart=/bin/mkdir -p /var/Users
+          ExecStart=-/bin/bash -c 'unshare -m -- /bin/sh -c "mount -o remount,rw / && ln -sf var/Users /Users"'
+
+          [Install]
+          WantedBy=local-fs.target

--- a/snc.sh
+++ b/snc.sh
@@ -342,4 +342,4 @@ ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- 'sudo mkdir /Users/foo && 
 
 # Remove the image stream of custom image
 retry ${OC} delete imagestream rhcos -n openshift-machine-config-operator
-retry ${OC} adm prune images --confirm --registry-url default-route-openshift-image-registry.apps-crc.testing --keep-younger-than=0s
+retry ${OC} adm prune images --confirm --registry-url default-route-openshift-image-registry.apps-crc.testing

--- a/snc.sh
+++ b/snc.sh
@@ -333,6 +333,3 @@ ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- 'sudo crictl rmi --prune'
 # Remove the baremetal_runtimecfg container which is temp created
 ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- "sudo podman rm baremetal_runtimecfg"
 
-# Create the /var/Users directory so it can become writeable
-# todo: remove it once custom image able to perform it
-${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- 'sudo mkdir /var/Users'

--- a/snc.sh
+++ b/snc.sh
@@ -280,14 +280,7 @@ FROM scratch
 RUN ln -sf var/Users /Users && mkdir /var/Users
 EOF
 podman build --from ${RHCOS_IMAGE} --authfile ${OPENSHIFT_PULL_SECRET_PATH} -t default-route-openshift-image-registry.apps-crc.testing/openshift-machine-config-operator/rhcos:latest --file ${INSTALL_DIR}/Containerfile .
-(
-    set +x # disable the logging in the subshell to prevent the password leakage
-    kubeadmin_pass=$(cat ${INSTALL_DIR}/auth/kubeadmin-password)
-    retry ${OC} login -u kubeadmin -p "$kubeadmin_pass" --insecure-skip-tls-verify=true api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN}:6443
-    rm -f ${INSTALL_DIR}/auth/kubeadmin-password
-    esc_pw="$(printf '%s' "$kubeadmin_pass" | sed -e 's/[\/&|\\]/\\&/g')"
-    sed -i "s|$esc_pw|REDACTED|g" "${INSTALL_DIR}/.openshift_install.log"
-)
+retry ${OC} login -u kubeadmin -p $(cat ${INSTALL_DIR}/auth/kubeadmin-password) --insecure-skip-tls-verify=true api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN}:6443
 retry ${OC} registry login -a ${INSTALL_DIR}/reg.json
 retry podman push --authfile ${INSTALL_DIR}/reg.json --tls-verify=false default-route-openshift-image-registry.apps-crc.testing/openshift-machine-config-operator/rhcos:latest
 cat << EOF > ${INSTALL_DIR}/custom-os-mc.yaml

--- a/snc.sh
+++ b/snc.sh
@@ -337,8 +337,6 @@ ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- "sudo podman rm baremetal_
 # todo: remove it once custom image able to perform it
 ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- 'sudo mkdir /var/Users'
 
-# Check /Users directory is writeable
-${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- 'sudo mkdir /Users/foo && sudo rm -fr /Users/foo'
 
 # Remove the image stream of custom image
 retry ${OC} delete imagestream rhcos -n openshift-machine-config-operator

--- a/snc.sh
+++ b/snc.sh
@@ -267,9 +267,9 @@ wait_till_cluster_stable
 # This section is used to create a custom-os image which have `/Users`
 # For more details check https://github.com/crc-org/snc/issues/1041#issuecomment-2785928976
 # This should be performed before removing pull secret
-# Set tmp KUBECONFIG because default kubeconfig have `system:admin` user which doesn't able to create
+# Unsetting KUBECONFIG is required because it has default `system:admin` user which doesn't able to create
 # token to login to registry and kubeadmin user is required for that.
-export KUBECONFIG=/tmp/kubeconfig
+unset KUBECONFIG
 if [[ ${BUNDLE_TYPE} == "okd" ]]; then
      RHCOS_IMAGE=$(${OC} adm release info -a ${OPENSHIFT_PULL_SECRET_PATH} ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} --image-for=stream-coreos)
 else
@@ -305,6 +305,7 @@ done
 BAREMETAL_RUNTIMECFG=$(${OC} adm release info -a ${OPENSHIFT_PULL_SECRET_PATH} ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} --image-for=baremetal-runtimecfg)
 ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- "sudo podman create --authfile /var/lib/kubelet/config.json --name baremetal_runtimecfg ${BAREMETAL_RUNTIMECFG}"
 
+export KUBECONFIG=${INSTALL_DIR}/auth/kubeconfig
 mc_before_removing_pullsecret=$(retry ${OC} get mc --sort-by=.metadata.creationTimestamp --no-headers -oname)
 # Replace pull secret with a null json string '{}'
 retry ${OC} replace -f pull-secret.yaml

--- a/snc.sh
+++ b/snc.sh
@@ -264,42 +264,6 @@ retry ${OC} delete mc chronyd-mask
 # Wait for the cluster again to become stable because of all the patches/changes
 wait_till_cluster_stable
 
-# This section is used to create a custom-os image which have `/Users`
-# For more details check https://github.com/crc-org/snc/issues/1041#issuecomment-2785928976
-# This should be performed before removing pull secret
-# Unsetting KUBECONFIG is required because it has default `system:admin` user which doesn't able to create
-# token to login to registry and kubeadmin user is required for that.
-unset KUBECONFIG
-if [[ ${BUNDLE_TYPE} == "okd" ]]; then
-     RHCOS_IMAGE=$(${OC} adm release info -a ${OPENSHIFT_PULL_SECRET_PATH} ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} --image-for=stream-coreos)
-else
-     RHCOS_IMAGE=$(${OC} adm release info -a ${OPENSHIFT_PULL_SECRET_PATH} ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} --image-for=rhel-coreos)
-fi
-cat << EOF > ${INSTALL_DIR}/Containerfile
-FROM scratch
-RUN ln -sf var/Users /Users && mkdir /var/Users
-EOF
-podman build --from ${RHCOS_IMAGE} --authfile ${OPENSHIFT_PULL_SECRET_PATH} -t default-route-openshift-image-registry.apps-crc.testing/openshift-machine-config-operator/rhcos:latest --file ${INSTALL_DIR}/Containerfile .
-retry ${OC} login -u kubeadmin -p $(cat ${INSTALL_DIR}/auth/kubeadmin-password) --insecure-skip-tls-verify=true api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN}:6443
-retry ${OC} registry login -a ${INSTALL_DIR}/reg.json
-podman push --authfile ${INSTALL_DIR}/reg.json --tls-verify=false default-route-openshift-image-registry.apps-crc.testing/openshift-machine-config-operator/rhcos:latest
-cat << EOF > ${INSTALL_DIR}/custom-os-mc.yaml
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-  labels:
-    machineconfiguration.openshift.io/role: master
-  name: custom-image
-spec:
-  osImageURL: image-registry.openshift-image-registry.svc:5000/openshift-machine-config-operator/rhcos:latest
-EOF
-retry ${OC} apply -f ${INSTALL_DIR}/custom-os-mc.yaml
-sleep 60
-# Wait till machine config pool is updated correctly
-while retry ${OC} get mcp master -ojsonpath='{.status.conditions[?(@.type!="Updated")].status}' | grep True; do
-    echo "Machine config still in updating/degrading state"
-done
-
 # Create a container from baremetal-runtimecfg image which consumed by nodeip-configuration service so it is
 # not deleted by `crictl rmi --prune` command
 BAREMETAL_RUNTIMECFG=$(${OC} adm release info -a ${OPENSHIFT_PULL_SECRET_PATH} ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} --image-for=baremetal-runtimecfg)
@@ -333,4 +297,5 @@ ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- 'sudo crictl rmi --prune'
 
 # Remove the baremetal_runtimecfg container which is temp created
 ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- "sudo podman rm baremetal_runtimecfg"
+
 

--- a/snc.sh
+++ b/snc.sh
@@ -336,8 +336,3 @@ ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- "sudo podman rm baremetal_
 # Create the /var/Users directory so it can become writeable
 # todo: remove it once custom image able to perform it
 ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- 'sudo mkdir /var/Users'
-
-
-# Remove the image stream of custom image
-retry ${OC} delete imagestream rhcos -n openshift-machine-config-operator
-retry ${OC} adm prune images --confirm --registry-url default-route-openshift-image-registry.apps-crc.testing

--- a/snc.sh
+++ b/snc.sh
@@ -282,7 +282,7 @@ EOF
 podman build --from ${RHCOS_IMAGE} --authfile ${OPENSHIFT_PULL_SECRET_PATH} -t default-route-openshift-image-registry.apps-crc.testing/openshift-machine-config-operator/rhcos:latest --file ${INSTALL_DIR}/Containerfile .
 retry ${OC} login -u kubeadmin -p $(cat ${INSTALL_DIR}/auth/kubeadmin-password) --insecure-skip-tls-verify=true api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN}:6443
 retry ${OC} registry login -a ${INSTALL_DIR}/reg.json
-retry podman push --authfile ${INSTALL_DIR}/reg.json --tls-verify=false default-route-openshift-image-registry.apps-crc.testing/openshift-machine-config-operator/rhcos:latest
+podman push --authfile ${INSTALL_DIR}/reg.json --tls-verify=false default-route-openshift-image-registry.apps-crc.testing/openshift-machine-config-operator/rhcos:latest
 cat << EOF > ${INSTALL_DIR}/custom-os-mc.yaml
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig

--- a/snc.sh
+++ b/snc.sh
@@ -196,6 +196,16 @@ retry ${OC} apply -f kubelet-bootstrap-cred-manager-ds.yaml
 retry ${OC} delete secrets/csr-signer-signer secrets/csr-signer -n openshift-kube-controller-manager-operator
 retry ${OC} adm wait-for-stable-cluster
 
+# Enable transient-ro in ostree to allow creating /Users top-level directory
+# This modifies prepare-root.conf and regenerates the initramfs, which takes
+# effect on the next reboot (triggered by pull secret removal below).
+retry ${OC} apply -f 99-enable-transient-ro.yaml
+sleep 60
+# Wait till machine config pool is updated correctly
+while retry ${OC} get mcp master -ojsonpath='{.status.conditions[?(@.type!="Updated")].status}' | grep True; do
+    echo "Machine config still in updating/degrading state"
+done
+
 if [[ ${CERT_ROTATION} == "enabled" ]]
 then
     renew_certificates
@@ -298,4 +308,5 @@ ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- 'sudo crictl rmi --prune'
 # Remove the baremetal_runtimecfg container which is temp created
 ${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- "sudo podman rm baremetal_runtimecfg"
 
-
+# Verify /Users is writable via transient-ro
+${SSH} core@api.${SNC_PRODUCT_NAME}.${BASE_DOMAIN} -- 'sudo mkdir /Users/foo && sudo rm -fr /Users/foo'


### PR DESCRIPTION
Replace the custom RHCOS container image approach for creating the
/Users top-level directory with ostree's transient-ro feature.

The previous approach built a custom container image with a /Users
symlink, pushed it to the in-cluster registry, and applied a
MachineConfig with osImageURL to deploy it. This was ~40 lines of
complex logic involving Containerfile creation, podman build/push,
kubeadmin login for registry access, and imagestream cleanup.

The new approach uses a MachineConfig with two systemd services:

1. enable-transient-ro.service (oneshot, runs once):
   - Uses rpm-ostree usroverlay to temporarily make /usr writable
   - Sets composefs.enabled from "maybe" to "yes" in prepare-root.conf
   - Appends [root] transient-ro = true to prepare-root.conf
   - Regenerates the bootloader initramfs with the updated config
   - Creates /var/Users as the symlink target

2. create-users-mount.service (runs every boot):
   - Creates /var/Users directory
   - Uses unshare -m to create /Users -> var/Users symlink on the
     transient-ro overlayfs root

The MachineConfig is included in the install manifests directory so
it is applied during initial cluster bootstrap, avoiding an extra
MCP reboot cycle.

Doc: https://bootc.dev/bootc/filesystem.html
Ref: https://github.com/crc-org/snc/issues/1041

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enable transient read-only workflow for /Users on master nodes, allowing /Users to be managed as a transient overlay and become writable when configured.

* **Chores**
  * Simplified provisioning to apply the transient-ro configuration directly during setup instead of building/pushing a custom image.
  * Updated provisioning verification to test writable /Users behavior; removed custom-image build/cleanup steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/crc-org/snc/pull/1228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->