### PR TITLE
Test: update the image to rhel-10 to test 9p kernel module

### DIFF
--- a/snc.sh
+++ b/snc.sh
@@ -273,7 +273,7 @@ export KUBECONFIG=/tmp/kubeconfig
 if [[ ${BUNDLE_TYPE} == "okd" ]]; then
      RHCOS_IMAGE=$(${OC} adm release info -a ${OPENSHIFT_PULL_SECRET_PATH} ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} --image-for=stream-coreos)
 else
-     RHCOS_IMAGE=$(${OC} adm release info -a ${OPENSHIFT_PULL_SECRET_PATH} ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} --image-for=rhel-coreos)
+     RHCOS_IMAGE=$(${OC} adm release info -a ${OPENSHIFT_PULL_SECRET_PATH} ${OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE} --image-for=rhel-coreos-10)
 fi
 cat << EOF > ${INSTALL_DIR}/Containerfile
 FROM scratch


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated image stream selection to ensure the correct RHCOS image is used when setting up cluster configurations, excluding OKD installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->