### PR TITLE
Add initial agents.md file and skill to compare 2 different OCP release payload size

### DIFF
--- a/.agents/skills/compare-bundle-size/SKILL.md
+++ b/.agents/skills/compare-bundle-size/SKILL.md
@@ -1,0 +1,28 @@
+# compare-bundle-size
+
+Compare the last-layer image sizes between two OpenShift release bundles.
+
+## When to use
+
+Trigger this skill when the user types `/compare-bundle-size` or asks to compare OpenShift bundle sizes, release sizes, or image layer growth between two versions.
+
+## Instructions
+
+1. Ask the user which two bundle versions they want to compare using `AskUserQuestion`. Provide common recent versions as options and allow free-text input via "Other".
+
+2. Once both versions are provided, run the comparison script:
+   ```
+   bash compare_bundle_size.sh <BUNDLE1> <BUNDLE2>
+   ```
+   The script lives at the project root: `.agents/skills/compare-bundle-size/compare_bundle_size.sh`
+
+3. Present the results to the user in a clear summary:
+   - Total size difference (printed to stderr by the script)
+   - Top images that grew the most (by absolute MB)
+   - Top images that shrank the most (by absolute MB)
+   - Any images with >50% growth as notable outliers
+
+4. If the script fails (e.g. missing `oc`, invalid version, network error), report the error clearly and suggest the user check:
+   - That `oc` CLI is installed and authenticated
+   - That `~/pull-secret` exists
+   - That the bundle version string is valid (e.g. `4.21.18`, `4.22.0-rc.5`)

--- a/.agents/skills/compare-bundle-size/compare_bundle_size.sh
+++ b/.agents/skills/compare-bundle-size/compare_bundle_size.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [-h] [BUNDLE1 BUNDLE2]
+
+Compare the last-layer image sizes between two OpenShift release bundles.
+
+Arguments:
+  BUNDLE1    First bundle version  (e.g. 4.21.18)
+  BUNDLE2    Second bundle version (e.g. 4.22.0-rc.5)
+
+If no arguments are provided, the script will prompt interactively.
+
+Options:
+  -h, --help    Show this help message and exit
+
+Examples:
+  $(basename "$0") 4.21.18 4.22.0-rc.5
+  $(basename "$0")
+EOF
+    exit "${1:-0}"
+}
+
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+    usage
+fi
+
+if [[ $# -eq 2 ]]; then
+    BUNDLE1="$1"
+    BUNDLE2="$2"
+elif [[ $# -eq 0 ]]; then
+    read -rp "Enter first bundle version (e.g. 4.21.18): " BUNDLE1
+    read -rp "Enter second bundle version (e.g. 4.22.0-rc.5): " BUNDLE2
+else
+    echo "Error: expected 0 or 2 arguments, got $#" >&2
+    usage 1
+fi
+
+if [[ -z "$BUNDLE1" || -z "$BUNDLE2" ]]; then
+    echo "Error: both bundle versions must be non-empty" >&2
+    exit 1
+fi
+
+BUNDLE1_SAFE="${BUNDLE1//[^a-zA-Z0-9.]/_}"
+BUNDLE2_SAFE="${BUNDLE2//[^a-zA-Z0-9.]/_}"
+
+# store payload info
+PULL_SECRET_PATH="${OPENSHIFT_PULL_SECRET_PATH:-${HOME}/pull-secret}"
+oc adm release info -a "${PULL_SECRET_PATH}" --output=json "quay.io/openshift-release-dev/ocp-release:${BUNDLE1}-x86_64" --size >"${BUNDLE1_SAFE}.json"
+oc adm release info -a "${PULL_SECRET_PATH}" --output=json "quay.io/openshift-release-dev/ocp-release:${BUNDLE2}-x86_64" --size >"${BUNDLE2_SAFE}.json"
+
+# extract size info
+jq -r '.images | to_entries[] | @text "\(.key) \(.value.layers[-1].size)"' "${BUNDLE1_SAFE}.json" >"last_layer_${BUNDLE1_SAFE}.size"
+jq -r '.images | to_entries[] | @text "\(.key) \(.value.layers[-1].size)"' "${BUNDLE2_SAFE}.json" >"last_layer_${BUNDLE2_SAFE}.size"
+
+awk -v b1="$BUNDLE1" -v b2="$BUNDLE2" '
+  BEGIN {print "image " b1 " " b2 " growth percent"}
+  FNR==NR {b1size[$1] = $2/1024/1024; seen[$1]=1; next}
+  {b2size[$1] = $2/1024/1024; seen[$1]=1}
+  END {
+    for (image in seen) {
+      diff = b2size[image] - b1size[image]
+      total_diff = total_diff + diff
+      printf "%s %d %d %dMB %.0f%%\n", image, b1size[image], b2size[image], diff, b1size[image] !=0 ? diff/b1size[image]*100: 100
+    }
+  printf "total diff: %gMB\n", total_diff >"/dev/stderr"
+  }' "last_layer_${BUNDLE1_SAFE}.size" "last_layer_${BUNDLE2_SAFE}.size" | column -t

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,5 +78,9 @@ The build pipeline has two phases, each with a library of shared functions:
 - VM IP is `192.168.126.11` on the `crc` libvirt network; DNS is configured via NetworkManager dnsmasq overlay
 - Bundle metadata lives in `crc-tmp-install-data/crc-bundle-info.json`
 
+# compare-bundle-size
+- **compare-bundle-size** (`.agents/skills/compare-bundle-size/SKILL.md`) - Compare last-layer image sizes between two OpenShift release bundles. Trigger: `/compare-bundle-size`
+When the user types `/compare-bundle-size`, invoke the Skill tool with `skill: "compare-bundle-size"` before doing anything else.
+
 # currentDate
 Today's date is 2026-06-03.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,82 @@
+# AGENTS.md
+
+This file provides guidance to AI agents when working with code in this repository.
+
+## Project Overview
+
+SNC (Single Node Cluster) creates OpenShift 4 / OKD / MicroShift bundles for [CRC (CodeReady Containers)](https://github.com/crc-org/crc). It provisions a single-node OpenShift cluster on a libvirt VM, configures it for local development use, then packages the VM disk image into platform-specific `.crcbundle` archives (libvirt/Linux, vfkit/macOS, Hyper-V/Windows).
+
+## Key Commands
+
+```bash
+# Lint all shell scripts (downloads shellcheck if missing)
+./shellcheck.sh
+
+# Build an OpenShift SNI cluster (requires OPENSHIFT_PULL_SECRET_PATH, libvirt, ~90 min)
+./snc.sh
+
+# Build a MicroShift cluster (requires subscription-manager registration)
+./microshift.sh
+
+# Package the running VM into .crcbundle archives
+./createdisk.sh crc-tmp-install-data
+
+# Full CI pipeline: shellcheck + snc.sh + createdisk.sh + conformance tests
+./ci.sh                # OpenShift
+./ci_microshift.sh     # MicroShift
+
+# Build patched KAO/KCMO operator images with 1-year certs
+./build-patched-kao-kcmo-images.sh
+
+# Wrap bundles into container images for registry distribution
+./gen-bundle-image.sh <version> <openshift|okd|microshift>
+```
+
+## Architecture
+
+The build pipeline has two phases, each with a library of shared functions:
+
+**Phase 1: Cluster provisioning** (`snc.sh` / `microshift.sh`)
+- Sources `tools.sh` (installs host dependencies: yq, jq, qemu-img, virsh, etc.) and `snc-library.sh` (libvirt VM lifecycle, cluster stabilization, cert rotation, preflight checks)
+- Creates a libvirt VM from RHCOS/FCOS ISO with single-node ignition config
+- Waits for OpenShift install, rotates certificates, configures htpasswd auth, image registry, CSI storage, CVO overrides
+- Outputs cluster state to `crc-tmp-install-data/`
+
+**Phase 2: Disk image packaging** (`createdisk.sh`)
+- Sources `tools.sh` and `createdisk-library.sh` (VM image sparsification, platform-specific bundle generation, systemd unit installation)
+- SSHs into the VM to install additional packages (cloud-init, gvisor-tap-vsock), configure networking (tap device, dnsmasq), deploy systemd services
+- Shuts down VM, sparsifies the qcow2 image, generates per-platform bundles (libvirt qcow2, vfkit raw, Hyper-V vhdx)
+- Compresses each bundle as `.crcbundle` using zstd
+
+**Bundle types** are determined by the entry script: `snc` (OpenShift), `okd` (OKD/SCOS), `microshift`. MicroShift uses `image-mode/microshift/build.sh` to create a bootc-based ISO instead of the openshift-installer flow.
+
+**Shared function libraries:**
+- `tools.sh` -- host tool detection/installation, architecture mapping (`ARCH` -> `yq_ARCH`), `retry` with exponential backoff, libvirt VM lifecycle (`create_vm`, `shutdown_vm`, `start_vm`, `destroy_libvirt_resources`)
+- `snc-library.sh` -- preflight checks, OC client download, cluster stabilization (`wait_till_cluster_stable`), cert renewal, PV/CSI provisioner setup, htpasswd generation
+- `createdisk-library.sh` -- qcow2 sparsification via guestfish, platform bundle generators (`generate_vfkit_bundle`, `generate_hyperv_bundle`), systemd unit deployment, tarball creation
+
+**Systemd services** in `systemd/` are installed into the VM and handle runtime concerns when CRC starts the bundle: DNS (dnsmasq), route management, cluster CA rotation, custom domains, pull secret injection, node readiness checks.
+
+## Environment Variables
+
+| Variable | Purpose |
+|---|---|
+| `OPENSHIFT_PULL_SECRET_PATH` | **Required.** Path to OpenShift pull secret JSON |
+| `OPENSHIFT_VERSION` | Pin a specific OCP version (otherwise uses latest candidate) |
+| `OKD_VERSION` | Build an OKD bundle instead of OCP |
+| `OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE` | Override the release image directly |
+| `SNC_PRODUCT_NAME` | VM/cluster name (default: `crc`) |
+| `SNC_GENERATE_LINUX_BUNDLE` / `_MACOS_` / `_WINDOWS_` | Set to `0` to skip platform bundle |
+| `CRC_ZSTD_EXTRA_FLAGS` | Zstd compression flags (default: `--ultra -22`) |
+| `MICROSHIFT_VERSION` | MicroShift version to build (default: `4.22`) |
+
+## Conventions
+
+- All scripts use `set -exuo pipefail` and source `tools.sh` first
+- SSH into the VM uses the generated `id_ecdsa_crc` keypair with strict host checking disabled
+- The `retry` function (exponential backoff, 14 retries) wraps most `oc` commands to handle transient API failures
+- VM IP is `192.168.126.11` on the `crc` libvirt network; DNS is configured via NetworkManager dnsmasq overlay
+- Bundle metadata lives in `crc-tmp-install-data/crc-bundle-info.json`
+
+# currentDate
+Today's date is 2026-06-03.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for AI agents operating in the repository, including command references, architecture overview, and key conventions.
  * Added documentation for the bundle size comparison skill.

* **New Features**
  * Added bundle size comparison capability to analyze and report image size differences across OpenShift release bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->