### PR TITLE
Update mirror url from ocp-dev-preview to ocp

### DIFF
--- a/ci_microshift.sh
+++ b/ci_microshift.sh
@@ -5,7 +5,7 @@ set -exuo pipefail
 sudo yum install -y git-core virtiofsd podman make golang
 
 ./shellcheck.sh
-MICROSHIFT_PRERELEASE=yes ./microshift.sh
+./microshift.sh
 
 # Set the zstd compression level to 10 to have faster
 # compression while keeping a reasonable bundle size.

--- a/microshift.sh
+++ b/microshift.sh
@@ -15,7 +15,7 @@ SNC_CLUSTER_MEMORY=${SNC_CLUSTER_MEMORY:-2048}
 SNC_CLUSTER_CPUS=${SNC_CLUSTER_CPUS:-2}
 CRC_VM_DISK_SIZE=${CRC_VM_DISK_SIZE:-31}
 BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
-MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp-dev-preview}
+MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp}
 MICROSHIFT_VERSION=${MICROSHIFT_VERSION:-4.22}
 MIRROR_REPO=${MIRROR_REPO:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/microshift/ocp-dev-preview/latest-${MICROSHIFT_VERSION}/el9/os}
 

--- a/snc.sh
+++ b/snc.sh
@@ -31,7 +31,7 @@ BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
 CRC_PV_DIR="/mnt/pv-data"
 SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
 SCP="scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"
-MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp-dev-preview}
+MIRROR=${MIRROR:-https://mirror.openshift.com/pub/openshift-v4/$ARCH/clients/ocp}
 CERT_ROTATION=${SNC_DISABLE_CERT_ROTATION:-enabled}
 USE_PATCHED_RELEASE_IMAGE=${SNC_USE_PATCHED_RELEASE_IMAGE:-disabled}
 HTPASSWD_FILE='users.htpasswd'


### PR DESCRIPTION
Since 4.22 is now released so this PR update the url and also remove prerelease env for microshift ci side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build process now uses standard OpenShift v4 client mirrors instead of development preview versions.
  * Prerelease mode behavior is no longer applied during startup by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->