### PR TITLE
[release-4.22] revert disk size to 31G and add workaround for download pods disk usuage.

### DIFF
--- a/99-enable-transient-ro.yaml
+++ b/99-enable-transient-ro.yaml
@@ -41,7 +41,7 @@ spec:
           Type=oneshot
           RemainAfterExit=yes
           ExecStart=/bin/mkdir -p /var/Users
-          ExecStart=-/bin/bash -c 'unshare -m -- /bin/sh -c "mount -o remount,rw / && ln -sf var/Users /Users"'
+          ExecStart=-/bin/bash -c 'unshare -m -- /bin/sh -c "mount --options-source=disable -o remount,rw / && ln -sf var/Users /Users"'
 
           [Install]
           WantedBy=local-fs.target

--- a/snc.sh
+++ b/snc.sh
@@ -26,7 +26,7 @@ INSTALL_DIR=crc-tmp-install-data
 SNC_PRODUCT_NAME=${SNC_PRODUCT_NAME:-crc}
 SNC_CLUSTER_MEMORY=${SNC_CLUSTER_MEMORY:-14336}
 SNC_CLUSTER_CPUS=${SNC_CLUSTER_CPUS:-6}
-CRC_VM_DISK_SIZE=${CRC_VM_DISK_SIZE:-43}
+CRC_VM_DISK_SIZE=${CRC_VM_DISK_SIZE:-31}
 BASE_DOMAIN=${CRC_BASE_DOMAIN:-testing}
 CRC_PV_DIR="/mnt/pv-data"
 SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i id_ecdsa_crc"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the system’s transient read-only startup sequence by adjusting how mount options are applied during the user-mount service.
* **Configuration**
  * Changed the default virtual machine disk size to 31 (from 43) when no disk size is provided via environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->