### PR TITLE
route: Add network policy for ingress

### DIFF
--- a/routes-controller.yaml.in
+++ b/routes-controller.yaml.in
@@ -20,4 +20,26 @@ spec:
       - image: quay.io/crcont/routes-controller:${TAG}
         name: routes-controller
         imagePullPolicy: IfNotPresent
-
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app: routes-controller
+  name: routes-controller
+  namespace: openshift-ingress
+spec:
+  egress:
+  - {}
+  ingress:
+  - ports:
+    - port: http
+      protocol: TCP
+    - port: https
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: routes-controller
+  policyTypes:
+  - Ingress
+  - Egress


### PR DESCRIPTION
From OCP-4.22 openshift-dns, openshift-ingress ..etc. core namespaces have default network policy so any pod which is created on these namespace will not have access to even internal dns. This PR add the network policy for routes-controller which is deployed in openshift-ingress

- https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/network_security/network-policy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Implemented a Kubernetes NetworkPolicy for the routes controller service to enhance network isolation. Inbound traffic is now restricted to TCP connections on the designated `http` and `https` ports only. Outbound traffic remains unrestricted, allowing egress to reach any destination. This reduces unintended access paths while preserving required connectivity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->