### PR TITLE
Route-controller: Add CRC_HOSTS_API_TOKEN env for pod

### DIFF
--- a/routes-controller.yaml.in
+++ b/routes-controller.yaml.in
@@ -20,6 +20,12 @@ spec:
       - image: quay.io/crcont/routes-controller:${TAG}
         name: routes-controller
         imagePullPolicy: IfNotPresent
+        env:
+        - name: CRC_HOSTS_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: crc-hosts-api-token
+              key: CRC_HOSTS_API_TOKEN
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
This token is fetched from the secret which is created during crc start and used as bearer token during hosts/add or hosts/remove api call when a route created or removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured the routes controller to securely access its hosts API token.
  * Improved integration with the hosts service without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->